### PR TITLE
Add miscellaneous common config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,50 @@
+# Summary: coding style configuration for editors that read .editorconfig.
+#
+# EditorConfig defines a file format for specifying some common coding style
+# parameters. Many editors recognize .editorconfig files automatically, and
+# there exist plugins for other editors. See https://spec.editorconfig.org/.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+spelling_language = en-US
+trim_trailing_whitespace = true
+
+[*.BUILD,*.bzl,*.bazel]
+# Google doesn't have a style guideline for Bazel files. Most people use 4.
+indent_size = 4
+
+[*.cc,*.h]
+# This matches Google style guidelines.
+indent_size = 2
+
+[*.py]
+indent_size = 4
+# This deviates from the Google style guidelines, which stipulate 80.
+max_line_length = 100
+
+[*.sh]
+# Both of the following values diverge from Google's shell script style.
+indent_size = 4
+max_line_length = 100
+
+# The following is used by shfmt. This brings it closer to Google's style.
+binary_next_line = true
+shell_variant = bash
+space_redirects = true
+switch_case_indent = true
+
+# If this repository has a "third_party" directory, ignore it entirely.
+# Note: shfmt also respects this if you run it with --appply-ignore.
+[third_party/**]
+ignore = true
+
+[*.yml,*.yaml]
+# Google doesn't have style guidelines for YAML, so we're on our own.
+indent_size = 2
+max_line_length = 100

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,152 @@
+{ // Summary: markdownlint config file for Quantumlib projects    -*- jsonc -*-
+  //
+  // Note: there are multiple programs programs named "markdownlint". We use
+  // https://github.com/igorshubovych/markdownlint-cli/, which is the one you
+  // get with "brew install markdownlint" on MacOS.
+  //
+  // These settings try to stay close to the Google Markdown Style as
+  // described at https://google.github.io/styleguide/docguide/style.html
+  //
+  // For a list of configuration options, see the following page:
+  // https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+  // (Beware that the above looks similar but is NOT the same as the page
+  // https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md.)
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+
+  // Require ATX-style headings.
+  // https://google.github.io/styleguide/docguide/style.html#atx-style-headings
+  "headings": {
+    "style": "atx"
+  },
+
+  // Google style does not require that the first line of a file is a heading
+  // for the title; it only states that the first heading should be a level 1.
+  // https://google.github.io/styleguide/docguide/style.html#document-layout
+  "first-line-heading": false,
+
+  // The Google style does not define what to do about trailing punctuation in
+  // headings. The markdownlint default disallows exclamation points, which
+  // seems likely to be more annoying than useful – I have definitely seen
+  // people use exclamation points in headings in README files on GitHub.
+  // This setting removes exclamation point from the banned characters.
+  "no-trailing-punctuation": {
+    "punctuation": ".,;:。，；："
+  },
+
+  // No trailing spaces.
+  // https://google.github.io/styleguide/docguide/style.html#trailing-whitespace
+  "whitespace": {
+    "br_spaces": 0
+  },
+
+  // Google style exempts some constructs from the line-length limit of 80 chars.
+  // https://google.github.io/styleguide/docguide/style.html#exceptions
+  "line-length": {
+    "code_blocks": false,
+    "headings": false,
+    "tables": false
+  },
+
+  // Google Markdown style specifies 2 spaces after item numbers, 3 spaces
+  // after bullets, so that the text itself is consistently indented 4 spaces.
+  // https://google.github.io/styleguide/docguide/style.html#nested-list-spacing
+  "list-marker-space": {
+    "ol_multi": 2,
+    "ol_single": 2,
+    "ul_multi": 3,
+    "ul_single": 3
+  },
+
+  "ul-indent": {
+    "indent": 4
+  },
+
+  // Bare URLs are allowed in GitHub-flavored Markdown and in Google’s style.
+  "no-bare-urls": false,
+
+  // Basic Markdown allows raw HTML. Both GitHub & PyPI support subsets of
+  // HTML, though it's unclear what subset PyPI supports. Google's style
+  // guide doesn't disallow using HTML, although it recommends against it. (C.f.
+  // the bottom of https://google.github.io/styleguide/docguide/style.html)
+  // It's worth noting, though, that Google's guidance has Google's internal
+  // documentation system in mind, and that system extends Markdown with
+  // constructs that make it possible to accomplish things you can't do in
+  // Markdown. Those extensions are also not available outside Google's system.
+  // Thus, although a goal of this markdownlint configuration is to match
+  // Google's style guide as closely as possible, these various factors suggest
+  // it's reasonable to relax the HTML limitation. The list below is based on
+  // https://github.com/github/markup/issues/245#issuecomment-682231577 plus
+  // some things found elsewhere after that was written.
+  "html": {
+    "allowed_elements": [
+      "a",
+      "abbr",
+      "b",
+      "bdo",
+      "blockquote",
+      "br",
+      "caption",
+      "cite",
+      "code",
+      "dd",
+      "del",
+      "details",
+      "dfn",
+      "div",
+      "dl",
+      "dt",
+      "em",
+      "figcaption",
+      "figure",
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "h7",
+      "h8",
+      "hr",
+      "i",
+      "img",
+      "ins",
+      "kbd",
+      "li",
+      "mark",
+      "ol",
+      "p",
+      "picture",
+      "pre",
+      "q",
+      "rp",
+      "rt",
+      "ruby",
+      "s",
+      "samp",
+      "small",
+      "source",
+      "span",
+      "span",
+      "strike",
+      "strong",
+      "sub",
+      "summary",
+      "sup",
+      "table",
+      "tbody",
+      "td",
+      "tfoot",
+      "th",
+      "thead",
+      "time",
+      "tr",
+      "tt",
+      "ul",
+      "var",
+      "video",
+      "wbr"
+    ]
+  }
+}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,19 @@
+# Summary: config file for shellcheck program.
+#
+# The following page includes more information about the .shellcheckrc file:
+# https://github.com/koalaman/shellcheck/wiki/Directive#shellcheckrc-file
+# 
+# Optional settings can be discovered by running "shellcheck --list-optional".
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# We use bash for all the scripts, so tell shellcheck to assume this dialect.
+shell=bash
+
+# Makes shellcheck include files pointed-to by the source or . statements.
+external-sources=true
+
+# Enable check for when a script uses "set -e" but a construct may disable it.
+enable=check-set-e-suppressed
+
+# Enable check for tests like [ "$var" ], which are best written [ -n "$var" ].
+enable=avoid-nullary-conditions

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,14 @@
+# Summary: yamllint configuration.
+# See https://yamllint.readthedocs.io/ for info about configuration options.
+
+rules:
+  line-length:
+    # YAML files (especially GitHub Actions workflows) tend to end up with
+    # long lines. The default of 80 is pretty limiting, and besides, in Python
+    # code linting, we set line lengths to 100. May as well follow suit here.
+    max: 100
+    # Another common occurrence in YAML files is long URLs. The next two
+    # settings are not specific to URLs, but help. It saves developer time by
+    # not requiring comment directives to disable warnings at every occurrence.
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true


### PR DESCRIPTION
This adds several configuration files for editors and linters. Some of these are not used yet, but soon will be when additional workflows are added. Adding them now allows people to use the tools now if they want to.

- `.editorconfig`: [EditorConfig](https://spec.editorconfig.org) defines a file format for specifying some common coding style parameters. Many editors recognize `.editorconfig` files automatically, and there exist plugins for other editors. This particular `.editorconfig` file is the same as other Quantumlib projects.

- `.markdownlintrc`: config file for [markdownlint](https://github.com/igorshubovych/markdownlint-cli), a popular linter for Markdown files. The settings here try to be as close to the Google style as possible while still being compatible with GitHub-flavored Markdown.

- `.shellcheckrc`: config file for [shellcheck](https://github.com/koalaman/shellcheck), a static analysis tool for shell scripts.

- `.yamllint.yaml`: config file for [yamllint](https://yamllint.readthedocs.io/en), a linter for YAML files. The config file sets the line length to the same as what's used for the `black` configuration, for consistency.