### PR TITLE
Add security & code health workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,89 @@
+# Zero-configuration modular workflow to run CodeQL code scans.
+#
+# CodeQL is a semantic code analysis tool that finds vulnerabilities by
+# understanding the code's logic. It is provided by GitHub. CodeQL's findings
+# are reported in the repo's code-scanning results page,
+# https://github.com/quantumlib/REPO/security/code-scanning/.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: CodeQL code scan
+run-name: Run CodeQL code scan ${{inputs.reason}}
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - master
+
+  # Support merge queues.
+  merge_group:
+    types:
+      - checks_requested
+
+  # Allow manual invocation.
+  workflow_dispatch:
+
+  # Allow calling from nightly.yaml.
+  workflow_call:
+    inputs:
+      reason:
+        type: string
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  create-matrix:
+    name: Determine languages used
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      language-matrix: ${{steps.matrix.outputs.languages}}
+    steps:
+      - name: Get list of programming languages used in this repo
+        id: matrix
+        uses: advanced-security/set-codeql-language-matrix@975244ea2e4c0668b8d289ac2b61fa7f0976f328 # v1
+        with:
+          access-token: ${{secrets.GITHUB_TOKEN}}
+          endpoint: ${{github.event.repository.languages_url}}
+
+  codeql:
+    if: ${{needs.create-matrix.outputs.language-matrix != '[]'}}
+    name: Run CodeQL scanner for ${{matrix.language}}
+    needs: create-matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{fromJSON(needs.create-matrix.outputs.language-matrix)}}
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL scanning tool
+        uses: github/codeql-action/init@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3
+        with:
+          languages: ${{matrix.language}}
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - '**/*.gltf'
+              - '**/*.json'
+              - '**/*.md'
+              - '**/*.png'
+              - '**/*.rst'
+              - '**/*.svg'
+              - '**/*.stim'
+              - '**/*.txt'
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Get list of programming languages used in this repo
         id: matrix
-        uses: advanced-security/set-codeql-language-matrix@975244ea2e4c0668b8d289ac2b61fa7f0976f328 # v1
+        uses: advanced-security/set-codeql-language-matrix@975244ea2e4c0668b8d289ac2b61fa7f0976f328
         with:
           access-token: ${{secrets.GITHUB_TOKEN}}
           endpoint: ${{github.event.repository.languages_url}}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,42 @@
+# Run regular code scans and other checks every night.
+#
+# This workflow calls other workflows to do code scans on a schedule.
+# It can also be invoked manually via the "Run workflow" button at
+# https://github.com/quantumlib/REPO/actions/workflows/nightly.yaml
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: Nightly code scans
+run-name: Run nightly tests and code scans in ${{github.repository}}
+
+on:
+  schedule:
+    - cron: '15 2 * * *'
+
+  # Allow manual invocation.
+  workflow_dispatch:
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  codeql:
+    name: Nightly CodeQL code scan
+    uses: ./.github/workflows/codeql.yaml
+    permissions: write-all
+    with:
+      reason: '(nightly)'
+
+  osv:
+    name: Nightly OSV code scan
+    uses: ./.github/workflows/osv-scanner.yaml
+    permissions: write-all
+    with:
+      reason: '(nightly)'
+
+  scorecard:
+    name: Nightly Scorecard analysis
+    uses: ./.github/workflows/scorecard.yaml
+    permissions: write-all
+    secrets: inherit
+    with:
+      reason: '(nightly)'

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,0 +1,88 @@
+# Zero-config modular workflow to run Open Source Vulnerabilities code scans.
+#
+# The OSV scanner is a dependency vulnerability scanner that identifies known
+# vulnerabilities in a project's dependencies. It supports C/C++, Python, Java,
+# JavaScript, and others. The findings are reported in the repo's code-scanning
+# results page, https://github.com/quantumlib/REPO/security/code-scanning/.
+#
+# The OSV project provides a GA workflow that you can reference as a step with
+# "uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml".
+# Unfortunately, that workflow inexplicably doesn't use the latest version of
+# the scanner and reporter workflows, and also does other things like hard-code
+# the value of the osv-scanner "--gh-annotations" option to "false". Using the
+# separate scanner & reporter actions allows us to adjust the options and use
+# Dependabot to update the workflow versions as new ones are introduced.
+#
+# For more examples and options, including how to ignore specific
+# vulnerabilities, see https://google.github.io/osv-scanner/github-action/.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: OSV code scan
+run-name: Run OSV vulnerability scanner ${{inputs.reason}}
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - master
+
+  # Support merge queues.
+  merge_group:
+    types:
+      - checks_requested
+
+  # Allow manual invocation.
+  workflow_dispatch:
+
+  # Allow calling from nightly.yaml.
+  workflow_call:
+    inputs:
+      reason:
+        type: string
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  osv-scan:
+    name: Run OSV scanner
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Read commit contents
+      contents: read
+      actions: read
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run OSV scanner on the repository files
+        # yamllint disable rule:line-length
+        uses: google/osv-scanner-action/osv-scanner-action@f8115f2f28022984d4e8070d2f0f85abcf6f3458 # v1.9.2
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --format=json
+            --output=osv-results.json
+            --recursive
+            ./
+
+      - name: Run OSV reporter on the results of the scan
+        # yamllint disable rule:line-length
+        uses: google/osv-scanner-action/osv-reporter-action@f8115f2f28022984d4e8070d2f0f85abcf6f3458 # v1.9.2
+        with:
+          scan-args: |-
+            --output=osv-results.sarif
+            --new=osv-results.json
+            --gh-annotations=true
+            --fail-on-vuln=true
+
+      - name: Upload to the repository's code-scanning results dashboard
+        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
+        with:
+          sarif_file: osv-results.sarif

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -6,14 +6,12 @@
 # results page, https://github.com/quantumlib/REPO/security/code-scanning/.
 #
 # The OSV project provides a GA workflow that you can reference as a step with
-# "uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml".
-# Unfortunately, that workflow inexplicably doesn't use the latest version of
-# the scanner and reporter workflows, and also does other things like hard-code
-# the value of the osv-scanner "--gh-annotations" option to "false". Using the
-# separate scanner & reporter actions allows us to adjust the options and use
-# Dependabot to update the workflow versions as new ones are introduced.
+# uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml.
+# Unfortunately, that workflow hardcodes some behaviors (such as uploading the
+# SARIF file to the workflow Actions tab, which we rarely need). The workflow
+# below is basically a heavily modified version of theirs.
 #
-# For more examples and options, including how to ignore specific
+# For more OSV scanner examples and options, including how to ignore specific
 # vulnerabilities, see https://google.github.io/osv-scanner/github-action/.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -50,39 +48,71 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Read commit contents
-      contents: read
+      # Needed to read commit contents:
       actions: read
+      # Needed to upload the results to code-scanning dashboard:
+      security-events: write
+      # Needed to upload SARIF file to CodeQL.
+      contents: read
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: false
+          fetch-depth: 0
 
-      - name: Run OSV scanner on the repository files
+      - name: Check out the target branch
+        run: |
+          git checkout ${{github.base_ref || github.ref_name}}
+          git submodule update --recursive
+
+      - name: Run OSV scanner on existing code
         # yamllint disable rule:line-length
-        uses: google/osv-scanner-action/osv-scanner-action@f8115f2f28022984d4e8070d2f0f85abcf6f3458 # v1.9.2
+        uses: google/osv-scanner-action/osv-scanner-action@119c605e0e6e6c491e092da25b0c752d109b0b43 # v2.0.0
         continue-on-error: true
         with:
           scan-args: |-
             --format=json
-            --output=osv-results.json
+            --output=old-results.json
+            --include-git-root
             --recursive
             ./
 
-      - name: Run OSV reporter on the results of the scan
+      - name: Check out current branch
+        # Use -f in case any changes were made by osv-scanner.
+        run: |
+          git checkout -f "$GITHUB_SHA"
+          git submodule update --recursive
+
+      - name: Run OSV scanner on new code
         # yamllint disable rule:line-length
-        uses: google/osv-scanner-action/osv-reporter-action@f8115f2f28022984d4e8070d2f0f85abcf6f3458 # v1.9.2
+        uses: google/osv-scanner-action/osv-scanner-action@119c605e0e6e6c491e092da25b0c752d109b0b43 # v2.0.0
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --format=json
+            --output=new-results.json
+            --include-git-root
+            --recursive
+            ./
+
+      - name: Run the OSV scanner reporter
+        # yamllint disable rule:line-length
+        uses: google/osv-scanner-action/osv-reporter-action@119c605e0e6e6c491e092da25b0c752d109b0b43 # v2.0.0
         with:
           scan-args: |-
             --output=osv-results.sarif
-            --new=osv-results.json
+            --old=old-results.json
+            --new=new-results.json
             --gh-annotations=true
             --fail-on-vuln=true
 
-      - name: Upload to the repository's code-scanning results dashboard
-        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
+      - name: Upload results to the repository's code-scanning results dashboard
+        id: upload_artifact
+        # yamllint disable rule:line-length
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
         with:
           sarif_file: osv-results.sarif
+
+      - name: Error troubleshooter
+        if: ${{always() && steps.upload_artifact.outcome == 'failure'}}
+        run: echo '::error::Artifact upload failed. Check the workflow logs.'

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,62 @@
+# Zero-configuration modular workflow to run the OSSF Scorecard scanner.
+#
+# Scorecard (https://github.com/ossf/scorecard) is a repository-scanning tool
+# that evaluates a project's security practices. Its use is suggested by
+# Google's GitHub team. Scorecard's findings are reported in a repo's scanning
+# results page, https://github.com/quantumlib/REPO/security/code-scanning/.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: Scorecard analysis
+run-name: Run Scorecard best-practices analyzer ${{inputs.reason}}
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - master
+
+  # Support merge queues.
+  merge_group:
+    types:
+      - checks_requested
+
+  # Allow manual invocation.
+  workflow_dispatch:
+
+  # Allow calling from nightly.yaml.
+  workflow_call:
+    inputs:
+      reason:
+        type: string
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Run Scorecard analyzer
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions: write-all
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          # Save the results
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish results to OpenSSF REST API.
+          # See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      - name: Upload results to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -37,8 +37,8 @@ jobs:
   scorecard:
     name: Run Scorecard analyzer
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
     permissions: write-all
+    timeout-minutes: 15
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -49,7 +49,7 @@ jobs:
         uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           # Save the results
-          results_file: results.sarif
+          results_file: scorecard-results.sarif
           results_format: sarif
 
           # Publish results to OpenSSF REST API.
@@ -59,4 +59,4 @@ jobs:
       - name: Upload results to code-scanning dashboard
         uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3
         with:
-          sarif_file: results.sarif
+          sarif_file: scorecard-results.sarif


### PR DESCRIPTION
This adds workflows for scanning repository files and assessing security issues and code/project health. Without any further configuration, the workflows will run once daily at night; they can also be added as CI checks in branch protection rules to trigger on pull requests.