### PR TITLE
Update BibTeX to put names in a more parseable form

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ preferred-citation:
   type: generic
   authors:
     - family-names: Aghababaie Beni
-      given-names: Laleh 
+      given-names: Laleh
     - family-names: Higgott
       given-names: Oscar
     - family-names: Shutty

--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ cite the following:
 ```latex
 @misc{beni2025tesseractdecoder,
     title={Tesseract: A Search-Based Decoder for Quantum Error Correction},
-    author={Laleh Aghababaie Beni and Oscar Higgott and Noah Shutty},
+    author = {Aghababaie Beni, Laleh and Higgott, Oscar and Shutty, Noah},
     year={2025},
     eprint={2503.10988},
     archivePrefix={arXiv},
     primaryClass={quant-ph},
+    doi = {10.48550/arXiv.2503.10988},
     url={https://arxiv.org/abs/2503.10988},
 }
 ```


### PR DESCRIPTION
Switching to this format for author names will hopefully increase the chances that tools and users will parse Laleh's last name correctly.