### PR TITLE
Add missing license headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,19 @@
-# Common editor configurations for this project.         -*- fill-column: 80 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Common editor configurations for this project.
 #
 # EditorConfig defines a file format for specifying some common coding style
 # parameters. Many IDEs and editors read .editorconfig files, either natively

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,4 +1,20 @@
-{ // Markdownlint config file for this project.                    -*- jsonc -*-
+{ // -*- jsonc -*-
+  // Copyright 2025 Google LLC
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     https://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Markdownlint linter configuration for this project.
   //
   // Note: there are multiple programs programs named "markdownlint". We use
   // https://github.com/igorshubovych/markdownlint-cli/, which is the one you


### PR DESCRIPTION
Apparently I misread guidance somewhere, and license headers are not
optional for these sorts of files after all.