### PR TITLE
Remove unnecessary config files & update others

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,0 @@
-;; Summary: Emacs editor configuration for this project.
-;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-((nil . ((fill-column . 100))))

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,25 +15,10 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Common editor configurations for this project.
 #
-# EditorConfig defines a file format for specifying some common coding style
-# parameters. Many IDEs and editors read .editorconfig files, either natively
-# or via plugins. A few formatters also read .editorconfig; shfmt and Prettier
-# are two examples (as of early 2025).
-#
+# EditorConfig is a file format for specifying some common style parameters.
+# Many IDEs & editors read .editorconfig files, either natively or via plugins.
 # We mostly follow Google's style guides (https://google.github.io/styleguide/)
-# with very few deviations.
-#
-# Miscellaneous notes:
-#
-# - The EditorConfig property `max_line_length` is not set here because its
-#   intended behavior is poorly specified. (See the discussion in the comments
-#   at https://github.com/editorconfig/editorconfig/issues/387) It *would* have
-#   been desirable to define a project convention for the line width here, but
-#   we must instead use editor-specific configuration files to do that.
-#
-# - With one known exception (shfmt), `.editorconfig` files are not read by
-#   linters or formatters, which means the project needs separate config files
-#   for those tools.
+# with only a few deviations for line length and indentation in some files.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 root = true
@@ -43,24 +28,15 @@ charset = utf-8
 indent_style = space
 insert_final_newline = true
 spelling_language = en-US
-# It would be preferable not to set tab_width, but some EditorConfig plugins
-# (e.g., Emacs's) set it equal to indent_size if it's not set otherwise.
-tab_width = 8
-# Trailing whitespace on lines is almost always noise. An exception is in
-# Markdown, where two spaces = line break; however, that's such a foot-gun in
-# practice that we avoid it. So, it's okay to set this next value globally.
 trim_trailing_whitespace = true
+max_line_length = 80
 
-[{BUILD,*.BUILD,*.bzl,*.bazel}]
+[{BUILD,*.BUILD,*.bzl,*.bazel,.bazelrc}]
 # Google doesn't have a style guideline for Bazel files. Most people use 4.
 indent_size = 4
 
 [{*.cc,*.h}]
-# This matches Google style guidelines.
-indent_size = 2
-
-[{*.ts,*.js}]
-# This matches Google style guidelines.
+# Google style guidelines use 2.
 indent_size = 2
 
 [*.json]
@@ -68,26 +44,12 @@ indent_size = 2
 indent_size = 2
 
 [*.py]
-# This matches Google style guidelines.
+# Google style guidelines use 4.
 indent_size = 4
 
-[*.rst]
-# Google doesn't have a style guideline for reStructuredText. Many people use 3.
-indent_size = 3
-
 [*.sh]
-# This matches Google style guidelines.
+# Google style guidelines use 2.
 indent_size = 2
-# The following are used by shfmt. These bring it closer to Google's style.
-binary_next_line = true
-shell_variant = bash
-space_redirects = true
-switch_case_indent = true
-
-# If this repository has a "third_party" directory, ignore it entirely.
-# Note: shfmt also respects this if you run it with --appply-ignore.
-[third_party/**]
-ignore = true
 
 [{*.yaml,*.yml}]
 # Google doesn't have style guidelines for YAML. Most people use indent = 2.

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -62,9 +62,9 @@
   // Google style exempts some constructs from the line-length limit:
   // https://google.github.io/styleguide/docguide/style.html#exceptions
   "line-length": {
-    "line_length": 100,
-    "code_block_line_length": 100,
-    "heading_line_length": 100,
+    "line_length": 80,
+    "code_block_line_length": 80,
+    "heading_line_length": 80,
     "code_blocks": false,
     "headings": false,
     "tables": false

--- a/.vimrc
+++ b/.vimrc
@@ -1,7 +1,0 @@
-" VIM editor configuration for this project.
-
-" Line length setting for this project.
-set textwidth=100
-
-" Encoding.
-set encoding=utf-8


### PR DESCRIPTION

This adjust the line length to 80 based on current project conventions,
adds `max_line_length` back to `.editorconfig`, and removes the
no-longer-necessary files `.vimrc` and `.dir-locals.el`.