### PR TITLE
Add affiliations to authors & do other edits

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,32 +1,32 @@
 # Citation information for this repository.                         -*- yaml -*-
 #
-# CITATION.cff files provide human- & machine-readable citation information for
-# software and datasets. GitHub, Zenodo, and the Zotero browser plugin all use
-# CFF files automatically if provided. https://citation-file-format.github.io/.
-#
-# Tools exist to generate CITATION.cff files from other formats such as BibTeX.
+# CITATION.cff provide human- & machine-readable citation info for software and
+# datasets. GitHub, Zenodo, and the Zotero browser plugin all use CFF files
+# automatically. Tools exist to generate CITATION.cff files from other formats
+# such as BibTeX. For more info, visit https://citation-file-format.github.io/.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 cff-version: 1.2.0
-message: If you use this software, please cite it using this metadata.
+message: >-
+  Please cite your use of Tesseract Decoder using the reference metadata
+  provided here.
 
-# CITATION.cff files describe how to cite software or datasets, with the goal of
-# making software and data be citable in their own right. However, sometimes
-# projects want citations to go to a paper instead. 'Preferred-citation' serves
-# to communicate that. The distinction matters in different situations. If this
-# field is present, GitHub uses the value for the "cite this repository" button
-# and ignores the rest of this file; conversely, the Zenodo-GitHub integration
-# ignores this field when creating an entry for a new software release (because
-# the Zenodo entry is specifically about the software in this repository).
+# If preferred-citation is present, GitHub uses its value for the "cite this
+# repository" button and ignores the rest of this file; conversely, the Zenodo-
+# GitHub integration ignores this field when archiving a new software release
+# and uses the metadata in the rest of this file.
 preferred-citation:
   type: generic
-  authors:
+  authors: &authors
     - family-names: Aghababaie Beni
       given-names: Laleh
+      affiliation: Google LLC
     - family-names: Higgott
       given-names: Oscar
+      affiliation: Google LLC
     - family-names: Shutty
       given-names: Noah
+      affiliation: Google LLC
   title: 'Tesseract: A Search-Based Decoder for Quantum Error Correction'
   year: 2025
   date-published: 2025-01-01
@@ -36,13 +36,7 @@ preferred-citation:
 # The remaining metadata in this file describes the current software release.
 
 title: Tesseract Decoder
-authors:
-  - family-names: Aghababaie Beni
-    given-names: Laleh
-  - family-names: Higgott
-    given-names: Oscar
-  - family-names: Shutty
-    given-names: Noah
+authors: *authors
 abstract: A Search-Based Decoder for Quantum Error Correction.
 date-released: 2025-03-12
 url: https://github.com/quantumlib/tesseract-decoder
@@ -53,6 +47,9 @@ identifiers:
   - description: Publication about Tesseract Decoder
     value: 10.48550/arXiv.2503.10988
     type: doi
+  - description: GitHub repository for Tesseract description
+    value: https://github.com/quantumlib/tesseract-decoder
+    type: url
 keywords:
   - A*
   - a-star


### PR DESCRIPTION

Changes:

- Add author affiliations
- Use a YAML anchor & alias to avoid repeating lists of authors
- Add another related info link
- Shorten the comments a bit