### PR TITLE
Replace std::vector<bool> with std::vector<char> for faster computations

### DIFF
--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -85,7 +85,7 @@ void TesseractDecoder::initialize_structures(size_t num_detectors) {
   }
 }
 
-struct VectorBoolHash {
+struct VectorCharHash {
   size_t operator()(const std::vector<char>& v) const {
     size_t seed = v.size(); // Still good practice to incorporate vector size
 
@@ -206,7 +206,7 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
 
   std::priority_queue<QNode, std::vector<QNode>, std::greater<QNode>> pq;
   std::unordered_map<size_t,
-                     std::unordered_set<std::vector<char>, VectorBoolHash>>
+                     std::unordered_set<std::vector<char>, VectorCharHash>>
       discovered_dets;
 
   size_t min_num_dets;

--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -23,9 +23,9 @@ bool Node::operator>(const Node& other) const {
 }
 
 double TesseractDecoder::get_detcost(size_t d,
-                                     const std::vector<bool>& blocked_errs,
+                                     const std::vector<char>& blocked_errs,
                                      const std::vector<size_t>& det_counts,
-                                     const std::vector<bool>& dets) const {
+                                     const std::vector<char>& dets) const {
   double min_cost = INF;
   for (size_t ei : d2e[d]) {
     if (!blocked_errs[ei]) {
@@ -86,14 +86,16 @@ void TesseractDecoder::initialize_structures(size_t num_detectors) {
 }
 
 struct VectorBoolHash {
-  size_t operator()(const std::vector<bool>& v) const {
-    std::hash<bool> bool_hash;
-    size_t seed = 0;
-    for (bool b : v) {
-      // Combine hash values of individual booleans.
-      // A simple way is to use XOR and bit shifting,
-      // but you can use other combining strategies as well.
-      seed ^= bool_hash(b) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  size_t operator()(const std::vector<char>& v) const {
+    size_t seed = v.size(); // Still good practice to incorporate vector size
+
+    // Iterate over char elements. Accessing 'b_val' is now a direct memory read.
+    for (char b_val : v) {
+      // The polynomial rolling hash with 31 (or another prime)
+      // 'b_val' is already a char (an 8-bit integer).
+      // static_cast<size_t>(b_val) ensures it's promoted to size_t before arithmetic.
+      // This cast is efficient (likely a simple register extension/move).
+      seed = seed * 31 + static_cast<size_t>(b_val);
     }
     return seed;
   }
@@ -151,7 +153,7 @@ bool QNode::operator>(const QNode& other) const {
 }
 
 void TesseractDecoder::to_node(const QNode& qnode,
-                               const std::vector<bool>& shot_dets,
+                               const std::vector<char>& shot_dets,
                                size_t det_order, Node& node) const {
   node.cost = qnode.cost;
   node.errs = qnode.errs;
@@ -197,20 +199,20 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
   size_t det_beam = config.det_beam;
   predicted_errors_buffer.clear();
   low_confidence_flag = false;
-  std::vector<bool> dets(num_detectors, false);
+  std::vector<char> dets(num_detectors, false);
   for (size_t d : detections) {
     dets[d] = true;
   }
 
   std::priority_queue<QNode, std::vector<QNode>, std::greater<QNode>> pq;
   std::unordered_map<size_t,
-                     std::unordered_set<std::vector<bool>, VectorBoolHash>>
+                     std::unordered_set<std::vector<char>, VectorBoolHash>>
       discovered_dets;
 
   size_t min_num_dets;
   {
     std::vector<size_t> errs;
-    std::vector<bool> blocked_errs(num_errors, false);
+    std::vector<char> blocked_errs(num_errors, false);
     std::vector<size_t> det_counts(num_errors, 0);
 
     for (size_t d = 0; d < num_detectors; ++d) {
@@ -238,8 +240,8 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
   size_t max_num_dets = min_num_dets + det_beam;
   Node node;
   std::vector<size_t> next_det_counts;
-  std::vector<bool> next_next_blocked_errs;
-  std::vector<bool> next_dets;
+  std::vector<char> next_next_blocked_errs;
+  std::vector<char> next_dets;
   std::vector<size_t> next_errs;
   while (!pq.empty()) {
     const QNode qnode = pq.top();
@@ -311,7 +313,7 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
     }
     // We cache as we recompute the det costs
     std::vector<double> det_costs(num_detectors, -1);
-    std::vector<bool> next_blocked_errs = node.blocked_errs;
+    std::vector<char> next_blocked_errs = node.blocked_errs;
     if (config.at_most_two_errors_per_detector) {
       for (int ei : d2e[min_det]) {
         // Block all errors of this detector -- note this is an approximation

--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -41,10 +41,10 @@ struct TesseractConfig {
 class Node {
  public:
   std::vector<size_t> errs;
-  std::vector<bool> dets;
+  std::vector<char> dets;
   double cost;
   size_t num_dets;
-  std::vector<bool> blocked_errs;
+  std::vector<char> blocked_errs;
 
   bool operator>(const Node& other) const;
 };
@@ -96,10 +96,10 @@ struct TesseractDecoder {
   size_t num_errors;
 
   void initialize_structures(size_t num_detectors);
-  double get_detcost(size_t d, const std::vector<bool>& blocked_errs,
+  double get_detcost(size_t d, const std::vector<char>& blocked_errs,
                      const std::vector<size_t>& det_counts,
-                     const std::vector<bool>& dets) const;
-  void to_node(const QNode& qnode, const std::vector<bool>& shot_dets,
+                     const std::vector<char>& dets) const;
+  void to_node(const QNode& qnode, const std::vector<char>& shot_dets,
                size_t det_order, Node& node) const;
 };
 

--- a/src/tesseract_main.cc
+++ b/src/tesseract_main.cc
@@ -317,7 +317,7 @@ struct Args {
 
 int main(int argc, char* argv[]) {
   std::cout.precision(16);
-  argparse::ArgumentParser program("simplex");
+  argparse::ArgumentParser program("tesseract");
   Args args;
   program.add_argument("--circuit")
       .help("Stim circuit file path")


### PR DESCRIPTION
While profiling tesseract, I noticed bottlenecks in the `to_node` function and `VectorBoolHash` function class when testing **Surface Code Transversal CX Protocols** for larger values of r, d and p (specifically, **r=11,d=11** and **r=13,d=13** and **p=0.002**). A significant percentage of decoding time was spent in code regions operating with `std::vector<bool>` data structures. Using these data structures to store boolean elements can be inefficient (see https://www.geeksforgeeks.org/problem-with-std-vector-bool-in-cpp/ for more detail).

In this PR, I replaced `std::vector<bool>` data structures inside the `TesseractDecoder` class with `std::vector<char>` and retained statements that were assigning true/false literal values to specific elements, as they can be implicitly converted to a char (1 or 0). I also slightly modified the logic for hashing the array of boolean elements in the `VectorBoolHash` function class.

I tested and evaluated the performance impact of this optimization on a **single shot/simulation of a quantum circuit for larger search problems of  Surface Code Transversal CX Protocols**. I performed 10 runs with a fixed seed for generating a shot/simulation and detectors ordering and computed the average decoding time across those runs. 

Note that when performing runs of multiple shots, the optimization will be propagated on each shot and the final result will contain performance improvement aggregated (summed up) across each shot.

![Screenshot 2025-05-28 10 49 57 AM](https://github.com/user-attachments/assets/9fe3abf3-ef51-4da6-9398-50958ecc33b7)
<b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Performance Impact on Surface Code Transversal CX Protocols (r=13, d=13, p=0.0005, p=0.001, Short Beam)</b>

![Screenshot 2025-05-28 10 51 25 AM](https://github.com/user-attachments/assets/a8dbd93b-e43a-4f6b-82a2-a1d2c9b5bc8b)
<b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Performance Impact on Surface Code Transversal CX Protocols (r=13, d=13, p=0.0005, p=0.001, Long Beam)</b>

![Screenshot 2025-05-28 10 52 53 AM](https://github.com/user-attachments/assets/2121f1b2-9f75-4ef1-8d55-b982e96cc264)
<b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Performance Impact on Surface Code Transversal CX Protocols (r=13, d=13, p=0.002, Short Beam)</b>

![Screenshot 2025-05-28 10 53 28 AM](https://github.com/user-attachments/assets/35f58749-4c27-4f1e-9c5f-1c944f4ad674)
<b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Time Reduction in Key Functions for Surface Code Transversal CX Protocols (r=13, d=13, p=0.002, Short Beam)</b>
