### PR TITLE
Accelerating 'get_detcost' function

### DIFF
--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -70,7 +70,6 @@ std::string Node::str()
   ss << "dets=" << self.dets << ", ";
   ss << "cost=" << self.cost << ", ";
   ss << "num_dets=" << self.num_dets << ", ";
-  ss << "blocked_errs=" << self.blocked_errs << ")";
   return ss.str();
 }
 
@@ -84,17 +83,23 @@ std::string QNode::str() {
   return ss.str();
 }
 
-double TesseractDecoder::get_detcost(size_t d,
-                                     const std::vector<char>& blocked_errs,
-                                     const std::vector<size_t>& det_counts) const {
+double TesseractDecoder::get_detcost(size_t d, 
+                                    const std::vector<DetectorCostTuple>& detector_cost_tuples) const {
   double min_cost = INF;
+  ErrorCost ec;
+  DetectorCostTuple dct;
+
   for (size_t ei : d2e[d]) {
-    if (!blocked_errs[ei]) {
-      double ecost = errors[ei].likelihood_cost / det_counts[ei];
-      min_cost = std::min(min_cost, ecost);
-      assert(det_counts[ei]);
+    ec = error_costs[ei];
+    dct = detector_cost_tuples[ei];
+    if (ec.min_cost >= min_cost) break;
+    if (!dct.error_blocked) {
+      double error_cost = ec.likelihood_cost / dct.detectors_count;
+      min_cost = std::min(min_cost, error_cost);
+      // assert(dct.detectors_count);
     }
   }
+
   return min_cost + config.det_penalty;
 }
 
@@ -131,11 +136,20 @@ void TesseractDecoder::initialize_structures(size_t num_detectors) {
     }
   }
 
+  for (size_t i = 0; i < errors.size(); ++i) {
+    error_costs.push_back({errors[i].likelihood_cost, errors[i].likelihood_cost / errors[i].symptom.detectors.size()});
+  }
+  
+  for (size_t d = 0; d < num_detectors; ++d) {
+    std::sort(d2e[d].begin(), d2e[d].end(), [this](size_t idx_a, size_t idx_b) {
+      return error_costs[idx_a].min_cost < error_costs[idx_b].min_cost;
+    });
+  }
+
   eneighbors.resize(num_errors);
   std::vector<std::unordered_set<size_t>> edets_sets(edets.size());
   for (size_t ei = 0; ei < edets.size(); ++ei) {
-    edets_sets[ei] =
-        std::unordered_set<size_t>(edets[ei].begin(), edets[ei].end());
+    edets_sets[ei] = std::unordered_set<size_t>(edets[ei].begin(), edets[ei].end());
   }
   for (size_t ei = 0; ei < num_errors; ++ei) {
     std::set<int> neighbor_set;
@@ -154,33 +168,24 @@ void TesseractDecoder::initialize_structures(size_t num_detectors) {
 
 struct VectorCharHash {
   size_t operator()(const std::vector<char>& v) const {
-    size_t seed = v.size();  // Still good practice to incorporate vector size
+    size_t seed = v.size();
 
-    // Iterate over char elements. Accessing 'b_val' is now a direct memory
-    // read.
     for (char b_val : v) {
-      // The polynomial rolling hash with 31 (or another prime)
-      // 'b_val' is already a char (an 8-bit integer).
-      // static_cast<size_t>(b_val) ensures it's promoted to size_t before
-      // arithmetic. This cast is efficient (likely a simple register
-      // extension/move).
       seed = seed * 31 + static_cast<size_t>(b_val);
     }
     return seed;
   }
 };
 
-void TesseractDecoder::decode_to_errors(
-    const std::vector<uint64_t>& detections) {
+void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections) {
   std::vector<size_t> best_errors;
   double best_cost = std::numeric_limits<double>::max();
   assert(config.det_orders.size());
-  int max_det_beam = config.det_beam;
+
   if (config.beam_climbing) {
-    for (int beam = max_det_beam; beam >= 0; --beam) {
-      config.det_beam = beam;
+    for (int beam = config.det_beam; beam >= 0; --beam) {
       size_t det_order = beam % config.det_orders.size();
-      decode_to_errors(detections, det_order);
+      decode_to_errors(detections, det_order, beam);
       double this_cost = cost_from_errors(predicted_errors_buffer);
       if (!low_confidence_flag && this_cost < best_cost) {
         best_errors = predicted_errors_buffer;
@@ -195,9 +200,8 @@ void TesseractDecoder::decode_to_errors(
       }
     }
   } else {
-    for (size_t det_order = 0; det_order < config.det_orders.size();
-         ++det_order) {
-      decode_to_errors(detections, det_order);
+    for (size_t det_order = 0; det_order < config.det_orders.size(); ++det_order) {
+      decode_to_errors(detections, det_order, config.det_beam);
       double this_cost = cost_from_errors(predicted_errors_buffer);
       if (!low_confidence_flag && this_cost < best_cost) {
         best_errors = predicted_errors_buffer;
@@ -213,7 +217,6 @@ void TesseractDecoder::decode_to_errors(
       }
     }
   }
-  config.det_beam = max_det_beam;
   predicted_errors_buffer = best_errors;
   low_confidence_flag = best_cost == std::numeric_limits<double>::max();
 }
@@ -222,17 +225,16 @@ bool QNode::operator>(const QNode& other) const {
   return cost > other.cost || (cost == other.cost && num_dets < other.num_dets);
 }
 
-void TesseractDecoder::to_node(const QNode& qnode,
-                               const std::vector<char>& shot_dets,
-                               size_t det_order, Node& node) const {
+void TesseractDecoder::to_node(const QNode& qnode, const std::vector<char>& shot_dets,
+                              size_t det_order, Node& node, 
+                              std::vector<DetectorCostTuple>& detector_cost_tuples) const {
   node.cost = qnode.cost;
   node.errs = qnode.errs;
   node.num_dets = qnode.num_dets;
-
-  // Reconstruct the dets and blocked_errs
   node.dets = shot_dets;
-  node.blocked_errs.resize(0);
-  node.blocked_errs.resize(num_errors, false);
+
+  detector_cost_tuples.resize(num_errors);
+
   for (size_t ei : node.errs) {
     // Get the min index activated detector before updating the dets
     size_t min_det = std::numeric_limits<size_t>::max();
@@ -242,9 +244,10 @@ void TesseractDecoder::to_node(const QNode& qnode,
         break;
       }
     }
+
     // Reconstruct the blocked_errs
     for (size_t oei : d2e[min_det]) {
-      node.blocked_errs[oei] = true;
+      detector_cost_tuples[oei].error_blocked = true;
       if (!config.at_most_two_errors_per_detector && oei == ei) break;
     }
 
@@ -253,16 +256,14 @@ void TesseractDecoder::to_node(const QNode& qnode,
       node.dets[d] = !node.dets[d];
       if (!node.dets[d] && config.at_most_two_errors_per_detector) {
         for (size_t oei : d2e[d]) {
-          node.blocked_errs[oei] = true;
+          detector_cost_tuples[oei].error_blocked = true;
         }
       }
     }
   }
 }
 
-void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
-                                        size_t det_order) {
-  size_t det_beam = config.det_beam;
+void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections, size_t det_order, size_t det_beam) {
   predicted_errors_buffer.clear();
   low_confidence_flag = false;
   std::vector<char> dets(num_detectors, false);
@@ -271,38 +272,36 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
   }
 
   std::priority_queue<QNode, std::vector<QNode>, std::greater<QNode>> pq;
-  std::unordered_map<size_t,
-                     std::unordered_set<std::vector<char>, VectorCharHash>>
-      discovered_dets;
+  std::unordered_map<size_t, std::unordered_set<std::vector<char>, VectorCharHash>> discovered_dets;
 
   size_t min_num_dets = detections.size();
   std::vector<size_t> errs;
-  std::vector<char> blocked_errs(num_errors, false);
-  std::vector<size_t> det_counts(num_errors, 0);
+  std::vector<DetectorCostTuple> detector_cost_tuples(num_errors);
 
   for (size_t d = 0; d < num_detectors; ++d) {
     if (!dets[d]) continue;
     for (int ei : d2e[d]) {
-      ++det_counts[ei];
+      ++detector_cost_tuples[ei].detectors_count;
     }
   }
+
   double initial_cost = 0.0;
   for (size_t d = 0; d < num_detectors; ++d) {
     if (!dets[d]) continue;
-    initial_cost += get_detcost(d, blocked_errs, det_counts);
+    initial_cost += get_detcost(d, detector_cost_tuples);
   }
+
   if (initial_cost == INF) {
     low_confidence_flag = true;
     return;
   }
-  // pq.push({errs, dets, initial_cost, min_num_dets, blocked_errs});
+
   pq.push({initial_cost, min_num_dets, errs});
 
   size_t num_pq_pushed = 1;
   size_t max_num_dets = min_num_dets + det_beam;
   Node node;
-  std::vector<size_t> next_det_counts;
-  std::vector<char> next_next_blocked_errs;
+  std::vector<DetectorCostTuple> next_detector_cost_tuples;
   std::vector<char> next_dets;
   std::vector<size_t> next_errs;
 
@@ -312,7 +311,8 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
       pq.pop();
       continue;
     }
-    to_node(qnode, dets, det_order, node);
+    std::vector<DetectorCostTuple> detector_cost_tuples;
+    to_node(qnode, dets, det_order, node, detector_cost_tuples);
     pq.pop();
 
     if (node.num_dets == 0) {
@@ -333,15 +333,13 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
         std::cout << "Decoding complete. Cost: " << node.cost
                   << " num_pq_pushed = " << num_pq_pushed << std::endl;
       }
-      // Store the predicted errors into the buffer
       predicted_errors_buffer = node.errs;
       return;
     }
 
     if (node.num_dets > max_num_dets) continue;
 
-    if (config.no_revisit_dets &&
-        !discovered_dets[node.num_dets].insert(node.dets).second) {
+    if (config.no_revisit_dets && !discovered_dets[node.num_dets].insert(node.dets).second) {
       continue;
     }
 
@@ -385,31 +383,28 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
       }
     }
 
-    // Recompute the det counts
-    std::vector<size_t> det_counts(num_errors, 0);
     for (size_t d = 0; d < num_detectors; ++d) {
       if (!node.dets[d]) continue;
       for (int ei : d2e[d]) {
-        ++det_counts[ei];
+        ++detector_cost_tuples[ei].detectors_count;
       }
     }
 
     // We cache as we recompute the det costs
     std::vector<double> det_costs(num_detectors, -1);
-    std::vector<char> next_blocked_errs = node.blocked_errs;
+    next_detector_cost_tuples = detector_cost_tuples;
     if (config.at_most_two_errors_per_detector) {
       for (int ei : d2e[min_det]) {
         // Block all errors of this detector -- note this is an approximation
         // where we insist at most 2 errors are incident to any detector
-        next_blocked_errs[ei] = true;
+        next_detector_cost_tuples[ei].error_blocked = true;
       }
     }
 
     // Consider activating any error of the lowest index activated detector
-    next_det_counts = det_counts;
     size_t last_ei = std::numeric_limits<size_t>::max();
     for (size_t ei : d2e[min_det]) {
-      if (node.blocked_errs[ei]) {
+      if (detector_cost_tuples[ei].error_blocked) {
         continue;
       }
 
@@ -419,13 +414,13 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
         for (int d : edets[last_ei]) {
           int fired = node.dets[d] ? 1 : -1;
           for (int oei : d2e[d]) {
-            next_det_counts[oei] += fired;
+            next_detector_cost_tuples[oei].detectors_count += fired;
           }
         }
       }
 
       last_ei = ei;
-      next_blocked_errs[ei] = true;
+      next_detector_cost_tuples[ei].error_blocked = true;
 
       next_errs = node.errs;
       next_errs.push_back(ei);
@@ -435,7 +430,7 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
 
       size_t next_num_dets = node.num_dets;
       if (config.at_most_two_errors_per_detector) {
-        next_next_blocked_errs = next_blocked_errs;
+        // next_next_blocked_errs = next_blocked_errs;
       }
 
       for (int d : edets[ei]) {
@@ -443,12 +438,12 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
         int fired = next_dets[d] ? 1 : -1;
         next_num_dets += fired;
         for (int oei : d2e[d]) {
-          next_det_counts[oei] += fired;
+          next_detector_cost_tuples[oei].detectors_count += fired;
         }
 
         if (!next_dets[d] && config.at_most_two_errors_per_detector) {
           for (size_t oei : d2e[d]) {
-            next_next_blocked_errs[oei] = true;
+            // next_next_blocked_errs[oei] = true;
           }
         }
       }
@@ -457,40 +452,36 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
         continue;
       }
 
-      if (config.no_revisit_dets &&
-          discovered_dets[next_num_dets].find(next_dets) !=
-              discovered_dets[next_num_dets].end()) {
+      if (config.no_revisit_dets && discovered_dets[next_num_dets].find(next_dets) != discovered_dets[next_num_dets].end()) {
         continue;
       }
 
       for (int d : edets[ei]) {
         if (node.dets[d]) {
           if (det_costs[d] == -1) {
-            det_costs[d] =
-                get_detcost(d, node.blocked_errs, det_counts);
+            det_costs[d] = get_detcost(d, detector_cost_tuples);
           }
           next_cost -= det_costs[d];
         } else {
-          next_cost += get_detcost(d, config.at_most_two_errors_per_detector ? next_next_blocked_errs : next_blocked_errs, next_det_counts);
+          // next_cost += get_detcost(d, config.at_most_two_errors_per_detector ? next_next_blocked_errs : next_blocked_errs, next_det_counts);
+          next_cost += get_detcost(d, next_detector_cost_tuples);
         }
       }
+
       for (size_t od : eneighbors[ei]) {
         if (!node.dets[od] || !next_dets[od]) continue;
         if (det_costs[od] == -1) {
-          det_costs[od] =
-              get_detcost(od, node.blocked_errs, det_counts);
+          det_costs[od] = get_detcost(od, detector_cost_tuples);
         }
         next_cost -= det_costs[od];
-        next_cost +=
-            get_detcost(od, config.at_most_two_errors_per_detector ? next_next_blocked_errs : next_blocked_errs, next_det_counts);
+        // next_cost += get_detcost(od, config.at_most_two_errors_per_detector ? next_next_blocked_errs : next_blocked_errs, next_det_counts);
+        next_cost += get_detcost(od, next_detector_cost_tuples);
       }
 
       if (next_cost == INF) {
         continue;
       }
 
-      // pq.push({next_errs, next_dets, next_cost, next_num_dets,
-      // next_blocked_errs});
       pq.push({next_cost, next_num_dets, next_errs});
       ++num_pq_pushed;
 
@@ -506,31 +497,27 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
     std::cout << "Decoding failed to converge within beam limit." << std::endl;
   }
   low_confidence_flag = true;
-  return;
 }
 
-double TesseractDecoder::cost_from_errors(
-    const std::vector<size_t>& predicted_errors) {
+double TesseractDecoder::cost_from_errors(const std::vector<size_t>& predicted_errors) {
   double total_cost = 0;
-  // Iterate over all errors and add to the mask
-  for (size_t ei : predicted_errors_buffer) {
+  // Iterate over all errors and compute the cost
+  for (size_t ei : predicted_errors) {
     total_cost += errors[ei].likelihood_cost;
   }
   return total_cost;
 }
 
-common::ObservablesMask TesseractDecoder::mask_from_errors(
-    const std::vector<size_t>& predicted_errors) {
+common::ObservablesMask TesseractDecoder::mask_from_errors(const std::vector<size_t>& predicted_errors) {
   common::ObservablesMask mask = 0;
-  // Iterate over all errors and add to the mask
-  for (size_t ei : predicted_errors_buffer) {
+  // Iterate over all errors and compute the mask
+  for (size_t ei : predicted_errors) {
     mask ^= errors[ei].symptom.observables;
   }
   return mask;
 }
 
-common::ObservablesMask TesseractDecoder::decode(
-    const std::vector<uint64_t>& detections) {
+common::ObservablesMask TesseractDecoder::decode(const std::vector<uint64_t>& detections) {
   decode_to_errors(detections);
   return mask_from_errors(predicted_errors_buffer);
 }

--- a/src/tesseract.pybind.h
+++ b/src/tesseract.pybind.h
@@ -50,17 +50,14 @@ void add_tesseract_module(py::module &root) {
       .def("__str__", &TesseractConfig::str);
 
   py::class_<Node>(m, "Node")
-      .def(py::init<std::vector<size_t>, std::vector<char>, double, size_t,
-                    std::vector<char>>(),
+      .def(py::init<std::vector<size_t>, std::vector<char>, double, size_t>(),
            py::arg("errs") = std::vector<size_t>(),
            py::arg("dets") = std::vector<char>(), py::arg("cost") = 0.0,
-           py::arg("num_dets") = 0,
-           py::arg("blocked_errs") = std::vector<char>())
+           py::arg("num_dets") = 0)
       .def_readwrite("errs", &Node::errs)
       .def_readwrite("dets", &Node::dets)
       .def_readwrite("cost", &Node::cost)
       .def_readwrite("num_dets", &Node::num_dets)
-      .def_readwrite("blocked_errs", &Node::blocked_errs)
       .def(py::self > py::self)
       .def("__str__", &Node::str);
 
@@ -81,9 +78,9 @@ void add_tesseract_module(py::module &root) {
                &TesseractDecoder::decode_to_errors),
            py::arg("detections"))
       .def("decode_to_errors",
-           py::overload_cast<const std::vector<uint64_t> &, size_t>(
+           py::overload_cast<const std::vector<uint64_t> &, size_t, size_t>(
                &TesseractDecoder::decode_to_errors),
-           py::arg("detections"), py::arg("det_order"))
+           py::arg("detections"), py::arg("det_order"), py::arg("det_beam"))
       .def("mask_from_errors", &TesseractDecoder::mask_from_errors,
            py::arg("predicted_errors"))
       .def("cost_from_errors", &TesseractDecoder::cost_from_errors,
@@ -93,7 +90,6 @@ void add_tesseract_module(py::module &root) {
                      &TesseractDecoder::low_confidence_flag)
       .def_readwrite("predicted_errors_buffer",
                      &TesseractDecoder::predicted_errors_buffer)
-      .def_readwrite("det_beam", &TesseractDecoder::det_beam)
       .def_readwrite("errors", &TesseractDecoder::errors);
 }
 

--- a/src/tesseract.pybind.h
+++ b/src/tesseract.pybind.h
@@ -50,26 +50,15 @@ void add_tesseract_module(py::module &root) {
       .def("__str__", &TesseractConfig::str);
 
   py::class_<Node>(m, "Node")
-      .def(py::init<std::vector<size_t>, std::vector<char>, double, size_t>(),
+      .def(py::init<double, size_t, std::vector<size_t>>(),
            py::arg("errs") = std::vector<size_t>(),
-           py::arg("dets") = std::vector<char>(), py::arg("cost") = 0.0,
+           py::arg("cost") = 0.0,
            py::arg("num_dets") = 0)
-      .def_readwrite("errs", &Node::errs)
-      .def_readwrite("dets", &Node::dets)
+      .def_readwrite("errs", &Node::errors)
       .def_readwrite("cost", &Node::cost)
-      .def_readwrite("num_dets", &Node::num_dets)
+      .def_readwrite("num_dets", &Node::num_detectors)
       .def(py::self > py::self)
       .def("__str__", &Node::str);
-
-  py::class_<QNode>(m, "QNode")
-      .def(py::init<double, size_t, std::vector<size_t>>(),
-           py::arg("cost") = 0.0, py::arg("num_dets") = 0,
-           py::arg("errs") = std::vector<size_t>())
-      .def_readwrite("cost", &QNode::cost)
-      .def_readwrite("num_dets", &QNode::num_dets)
-      .def_readwrite("errs", &QNode::errs)
-      .def(py::self > py::self)
-      .def("__str__", &QNode::str);
 
   py::class_<TesseractDecoder>(m, "TesseractDecoder")
       .def(py::init<TesseractConfig>(), py::arg("config"))


### PR DESCRIPTION
Function `get_detcost` is a bottleneck, especially in bivariate-bicycle codes and color codes. This function is frequently called inside the two major loops of the decoding process, when Tesseract computes the cost of a next search state. 

The initial implementation of the function receives two major arguments - vectors `blocked_errs` and `det_counts` that have the same `num_errors` number of elements. The function accesses errors from these two vectors at arbitrary indices, which are indices of errors connected with the detector for which the function value is being evaluated. In addition, the function accesses the `likelihood_cost`  field for each selected error using the `errors` vector, which stores each error as an `common::Error` object, computes the cost for each selected error and returns the minimum cost representing the cost of the detector.

Since memory locations in `blocked_errs` and `det_counts` are accessed at arbitrary, non-sequential indices, this can lead to frequent cache misses. However, the initial implementation overlooks an important detail: within each loop iteration, elements from both `blocked_errs` and `det_counts` are accessed at the same arbitrary index. This means that when one fetches an element from `blocked_errs`, potentially incurring a cache miss, it can also pre-fetch the corresponding element from `det_counts` at no additional cache penalty. This can be achieved by reorganizing these values into a structure that enhances data locality, specifically, creating a structure where `blocked_errs` and `det_counts` are adjacent fields. Furthermore, the design of the structure should be such that its total size aligns well with CPU cache lines (typically 64 bytes on most modern architectures).

I also implemented another optimization strategy called `Early Exit from Loop`. The loop inside the `get_detcost` function computes a cost for each error for the specific detector and returns the minimum cost as the detector cost. If inside the initialization phase we compute the lower bound for the error cost for each error, we can use these lower bound values when computing the detector cost. If we sort errors for each detector by their lower bound cost and inside the `get_detcost` loop we realize that the cost of the current error is at least the minimum cost we computed so far, we can exit the loop (as the lower bound of all the errors following the current error can't have a lower cost than the current we computed). I use a similar technique as I did with `blocked_errs` and `det_counts` to improve the data locality, by storing lower bound values for error costs (called `min_cost`) and the likely cost (called `likelihood_cost`) inside a single structure and fetching their values inside the `get_detcost` function, instead of fetching entire `common::Error` objects.

Below are graphs that evaluate the performance improvement I achieved using these two strategies for accelerating the `get_detcost` function. I present the results for the bivariate-bicycle codes and color codes. I evaluated the improvement in the execution time (seconds) and the improvement in cache misses (percent of cache misses spent in the `get_detcost` function). **For NLR10 bivariate-bicycle codes, I achieved an improvement of more than 50% in the execution time and an improvement of almost 50% for the cache misses. For color codes, I achieved almost 40% improvement in the execution time and more than 70% improvement for the cache misses.**

Note: values in brackets on the graph represent the performance improvement for a specific combination of optimization strategies.

![image](https://github.com/user-attachments/assets/514ae9ec-ccca-4ca1-b391-c483a3a5a4f0)

![image](https://github.com/user-attachments/assets/9b2570e8-713a-4710-bb09-ef7b8b9afe34)

![image](https://github.com/user-attachments/assets/5e7e5390-6ee2-47b6-95b6-5ebcb896672f)

![image](https://github.com/user-attachments/assets/13c464e7-c496-4df7-96d3-f39357af7983)

![image](https://github.com/user-attachments/assets/3cf398d2-3ebd-4b0e-8959-736a06da67b3)

![image](https://github.com/user-attachments/assets/fbc63cb8-cabe-457b-bc10-64d80bf07ee2)

![image](https://github.com/user-attachments/assets/61e97bf4-2242-4158-9731-afb0bd4169ff)

![image](https://github.com/user-attachments/assets/aa3d31b6-d0eb-4788-b065-add0ef8fb54d)
