### PR TITLE
fix naming issue that caused pypi to mismatch wheels

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,7 +24,6 @@ py_wheel(
     requires=[
         "stim",
     ],
-    abi="$(TARGET_VERSION)",
     python_tag="$(TARGET_VERSION)",
     platform= select({
         "@platforms//os:macos": "macosx_10_13_x86_64",


### PR DESCRIPTION
tested in this testpypi prerelease https://test.pypi.org/project/tesseract-decoder/0.1.2.dev20250715155105/