### PR TITLE
Use rooted URL for the image in SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,11 +8,12 @@ contributions.
 Please **do not** use GitHub issues to report security vulnerabilities; GitHub
 issues are public, and doing so could allow someone to exploit the information
 before the problem can be addressed. Instead, please use the *Report a
-vulnerability* interface from the _Security_ tab at the top of this GitHub
+vulnerability* interface from the *Security* tab at the top of this GitHub
 repository page.
 
 <div align="center">
-<img width="75%" src="./report-vulnerability-button.png">
+<img width="75%" alt="Location of the report button on the repository page"
+    src="/.github/report-vulnerability-button.png">
 </div>
 
 Please report security issues in third-party modules to the person or team


### PR DESCRIPTION
Turns out the security policy document is accessible on GitHub from at least two paths, and the relative image URL only worked in one and not the other. Using a rooted URL fixes that problem.