### PR TITLE
BUILD on old ubuntu to support colab

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,21 +30,18 @@ jobs:
           path: version
 
   build_wheels:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os_dist.os }}
     needs: [create_version]
     strategy:
       fail-fast: true
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        include:
-          - os: ubuntu-20.04
-            EXTRACT_GLIBC_VERSION: "yes"
-          - os: ubuntu-24.04
-            EXTRACT_GLIBC_VERSION: "yes"
-          - os: macos-13
-            EXTRACT_GLIBC_VERSION: "no"
-          - os: macos-14
-            EXTRACT_GLIBC_VERSION: "no"
+        os_dist: [
+          {os: ubuntu-20.04, EXTRACT_GLIBC_VERSION: "yes"},
+          {os: ubuntu-24.04, EXTRACT_GLIBC_VERSION: "yes"},
+          {os: macos-13, EXTRACT_GLIBC_VERSION: "no"},
+          {os: macos-14, EXTRACT_GLIBC_VERSION: "no"},
+        ]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Python
@@ -74,16 +71,16 @@ jobs:
     - name: Build package
       env:
         TARGET_PYTHON: ${{ matrix.python-version }}
-        EXTRACT_GLIBC_VERSION: ${{ matrix.EXTRACT_GLIBC_VERSION }}
+        EXTRACT_GLIBC_VERSION: ${{ matrix.os_dist.EXTRACT_GLIBC_VERSION }}
       run: |
-        GLIBC_VERSION=''
-        if [[ "$EXTRACT_GLIBC_VERSION"=='x' ]]; then s=$(ldd --version | awk '/ldd/{print $NF}'); GLIBC_VERSION=${s//./_}" fi
+        export GLIBC_VERSION=''
+        if [[ "$EXTRACT_GLIBC_VERSION"=='x' ]]; then s=$(ldd --version | awk '/ldd/{print $NF}'); export GLIBC_VERSION="${s//./_}"; fi
         echo $GLIBC_VERSION
         bazel build --define GLIBC_VERSION="$GLIBC_VERSION" --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:
-        name: python-wheels-${{ matrix.os }}-${{ matrix.python-version }}
+        name: python-wheels-${{ matrix.os_dist.os }}-${{ matrix.python-version }}
         path: ./bazel-bin/*.whl
 
   release-wheels:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -34,8 +34,8 @@ jobs:
     needs: [create_version]
     strategy:
       fail-fast: true
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+      matrix:  # ubuntu-22.04, 
+        os: [ubuntu-24.04, macos-13, macos-14]
         python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -70,6 +70,7 @@ jobs:
         glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
         export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION
+        sed "s/^MANYLINUX_VERSION.*/MANYLINUX_VERSION=\"manylinux_${GLIBC_VERSION}_x86_64.manylinux2014_x86_64\"/" BUILD -i || true
         bazel build --define GLIBC_VERSION=$GLIBC_VERSION --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -67,7 +67,7 @@ jobs:
       env:
         TARGET_PYTHON: ${{ matrix.python-version }}
       run: |
-        ldd --version || 0
+        ldd --version || true
         glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
         export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -34,8 +34,8 @@ jobs:
     needs: [create_version]
     strategy:
       fail-fast: true
-      matrix:  # ubuntu-22.04, 
-        os: [ubuntu-24.04, macos-13, macos-14]
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
         python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -67,7 +67,7 @@ jobs:
       env:
         TARGET_PYTHON: ${{ matrix.python-version }}
       run: |
-        ldd --version
+        ldd --version || 0
         glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
         export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -67,7 +67,7 @@ jobs:
         glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
         export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION
-        bazel build --define GLIBC_VERSION="$GLIBC_VERSION" --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
+        bazel build --define GLIBC_VERSION=$GLIBC_VERSION --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -30,18 +27,13 @@ jobs:
           path: version
 
   build_wheels:
-    runs-on: ${{ matrix.os_dist.os }}
+    runs-on: ${{ matrix.os }}
     needs: [create_version]
     strategy:
       fail-fast: true
       matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
         python-version: ['3.10', '3.11', '3.12']
-        os_dist: [
-          {os: ubuntu-20.04, EXTRACT_GLIBC_VERSION: "yes"},
-          {os: ubuntu-24.04, EXTRACT_GLIBC_VERSION: "yes"},
-          {os: macos-13, EXTRACT_GLIBC_VERSION: "no"},
-          {os: macos-14, EXTRACT_GLIBC_VERSION: "no"},
-        ]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Python
@@ -71,16 +63,16 @@ jobs:
     - name: Build package
       env:
         TARGET_PYTHON: ${{ matrix.python-version }}
-        EXTRACT_GLIBC_VERSION: ${{ matrix.os_dist.EXTRACT_GLIBC_VERSION }}
       run: |
-        export GLIBC_VERSION=''
-        if [[ "$EXTRACT_GLIBC_VERSION"=='x' ]]; then s=$(ldd --version | awk '/ldd/{print $NF}'); export GLIBC_VERSION="${s//./_}"; fi
+        ldd --version
+        glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
+        export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION
         bazel build --define GLIBC_VERSION="$GLIBC_VERSION" --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:
-        name: python-wheels-${{ matrix.os_dist.os }}-${{ matrix.python-version }}
+        name: python-wheels-${{ matrix.os }}-${{ matrix.python-version }}
         path: ./bazel-bin/*.whl
 
   release-wheels:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+  pull:
 
 permissions:
   contents: read
@@ -32,8 +33,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14]
         python-version: ['3.10', '3.11', '3.12']
+        include:
+          - os: ubuntu-20.04
+            EXTRACT_GLIBC_VERSION: "yes"
+          - os: ubuntu-24.04
+            EXTRACT_GLIBC_VERSION: "yes"
+          - os: macos-13
+            EXTRACT_GLIBC_VERSION: "no"
+          - os: macos-14
+            EXTRACT_GLIBC_VERSION: "no"
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Python
@@ -63,8 +72,12 @@ jobs:
     - name: Build package
       env:
         TARGET_PYTHON: ${{ matrix.python-version }}
+        EXTRACT_GLIBC_VERSION: ${{ matrix.EXTRACT_GLIBC_VERSION }}
       run: |
-        bazel build --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
+        GLIBC_VERSION=''
+        if [[ "$EXTRACT_GLIBC_VERSION"=='x' ]]; then s=$(ldd --version | awk '/ldd/{print $NF}'); GLIBC_VERSION=${s//./_}" fi
+        echo $GLIBC_VERSION
+        bazel build --define GLIBC_VERSION="$GLIBC_VERSION" --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
     - main
-  pull:
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -67,7 +64,6 @@ jobs:
       env:
         TARGET_PYTHON: ${{ matrix.python-version }}
       run: |
-        ldd --version || true
         glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
         export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -67,7 +67,8 @@ jobs:
         glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
         export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION
-        bazel build --define GLIBC_VERSION=$GLIBC_VERSION --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
+        sed "s/^MANYLINUX_VERSION.*/MANYLINUX_VERSION=\"manylinux_${GLIBC_VERSION}_x86_64.manylinux2014_x86_64\"/" BUILD -i || true
+        bazel build --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -3,7 +3,9 @@ name: Stable-release Tesseract
 on:
   release:
     types: [published]
-
+  pull_request:
+    branches:
+      - main
 permissions:
   contents: read
 

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
@@ -64,7 +64,10 @@ jobs:
       env:
         TARGET_PYTHON: ${{ matrix.python-version }}
       run: |
-        bazel build --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
+        glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
+        export GLIBC_VERSION="${glibc_version//./_}"
+        echo $GLIBC_VERSION
+        bazel build --define GLIBC_VERSION="$GLIBC_VERSION" --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -3,9 +3,7 @@ name: Stable-release Tesseract
 on:
   release:
     types: [published]
-  pull_request:
-    branches:
-      - main
+
 permissions:
   contents: read
 
@@ -69,7 +67,7 @@ jobs:
         glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
         export GLIBC_VERSION="${glibc_version//./_}"
         echo $GLIBC_VERSION
-        bazel build --define GLIBC_VERSION="$GLIBC_VERSION" --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
+        bazel build --define GLIBC_VERSION=$GLIBC_VERSION --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
 
     - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:

--- a/BUILD
+++ b/BUILD
@@ -29,7 +29,7 @@ py_wheel(
         ":macos_arm": "macosx_11_0_arm64",
         ":macos_x86": "macosx_10_13_x86_64",
         "@platforms//os:windows": "win32",
-        "@platforms//os:linux": "manylinux_2_17_x86_64.manylinux2014_x86_64",
+        "@platforms//os:linux": "manylinux_$(GLIBC_VERSION)_x86_64.manylinux2014_x86_64",
     }),
     strip_path_prefixes = ["src"],
     description_file=":package_description",

--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+MANYLINUX_VERSION="manylinux_2_17_x86_64.manylinux2014_x86_64"
+
 py_wheel(
     name="tesseract_decoder_wheel",
     distribution = "tesseract_decoder",
@@ -29,7 +31,7 @@ py_wheel(
         ":macos_arm": "macosx_11_0_arm64",
         ":macos_x86": "macosx_10_13_x86_64",
         "@platforms//os:windows": "win32",
-        "@platforms//os:linux": "manylinux_$(GLIBC_VERSION)_x86_64.manylinux2014_x86_64",
+        "@platforms//os:linux": MANYLINUX_VERSION,
     }),
     strip_path_prefixes = ["src"],
     description_file=":package_description",


### PR DESCRIPTION
colab has GLIBC 2.35 but building on ubuntu 24 makes us require 2.39 ... building on ubuntu 22 fixes the issue and I also extract the actual GLIBC version and attach it to the pypi wheel

fixes https://github.com/quantumlib/tesseract-decoder/issues/62