### PR TITLE
Add gaurds to redirect C++'s stdout/stderr streams to python's stdout/stderr streams

### DIFF
--- a/src/simplex.pybind.h
+++ b/src/simplex.pybind.h
@@ -15,6 +15,7 @@
 #ifndef _SIMPLEX_PYBIND_H
 #define _SIMPLEX_PYBIND_H
 
+#include <pybind11/iostream.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -63,7 +64,8 @@ void add_simplex_module(py::module& root) {
       .def_readwrite("end_time_to_errors", &SimplexDecoder::end_time_to_errors)
       .def_readonly("low_confidence_flag", &SimplexDecoder::low_confidence_flag)
       .def("init_ilp", &SimplexDecoder::init_ilp)
-      .def("decode_to_errors", &SimplexDecoder::decode_to_errors, py::arg("detections"))
+      .def("decode_to_errors", &SimplexDecoder::decode_to_errors, py::arg("detections"),
+           py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>())
       .def(
           "get_observables_from_errors",
           [](SimplexDecoder& self, const std::vector<size_t>& predicted_errors) {
@@ -88,6 +90,7 @@ void add_simplex_module(py::module& root) {
             }
             return result;
           },
-          py::arg("detections"));
+          py::arg("detections"),
+          py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>());
 }
 #endif

--- a/src/tesseract.pybind.cc
+++ b/src/tesseract.pybind.cc
@@ -14,6 +14,7 @@
 
 #include "tesseract.pybind.h"
 
+#include <pybind11/iostream.h>
 #include <pybind11/pybind11.h>
 
 #include "common.pybind.h"
@@ -23,8 +24,18 @@
 
 PYBIND11_MODULE(tesseract_decoder, tesseract) {
   py::module::import("stim");
+
   add_common_module(tesseract);
   add_utils_module(tesseract);
   add_simplex_module(tesseract);
   add_tesseract_module(tesseract);
+
+  // Adds a context manager to the python library that can be used to redirect C++'s stdout/stderr
+  // to python's stdout/stderr at run time like
+  // with tesseract_decoder.ostream_redirect(stdout=..., stderr=...):
+  //    do_work()
+  // This is only needed if the C++ function's stdout/stderr which is not redirected to python's
+  // stdout/stderr using the py::call_guard<py::scoped_ostream_redirect,
+  // py::scoped_estream_redirect>() statement.
+  py::add_ostream_redirect(tesseract, "ostream_redirect");
 }

--- a/src/tesseract.pybind.cc
+++ b/src/tesseract.pybind.cc
@@ -34,7 +34,7 @@ PYBIND11_MODULE(tesseract_decoder, tesseract) {
   // to python's stdout/stderr at run time like
   // with tesseract_decoder.ostream_redirect(stdout=..., stderr=...):
   //    do_work()
-  // This is only needed if the C++ function's stdout/stderr which is not redirected to python's
+  // This is only needed if the C++ function's stdout/stderr is not redirected to python's
   // stdout/stderr using the py::call_guard<py::scoped_ostream_redirect,
   // py::scoped_estream_redirect>() statement.
   py::add_ostream_redirect(tesseract, "ostream_redirect");

--- a/src/tesseract.pybind.h
+++ b/src/tesseract.pybind.h
@@ -15,6 +15,7 @@
 #ifndef _TESSERACT_PYBIND_H
 #define _TESSERACT_PYBIND_H
 
+#include <pybind11/iostream.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -71,11 +72,13 @@ void add_tesseract_module(py::module& root) {
       .def(py::init<TesseractConfig>(), py::arg("config"))
       .def("decode_to_errors",
            py::overload_cast<const std::vector<uint64_t>&>(&TesseractDecoder::decode_to_errors),
-           py::arg("detections"))
+           py::arg("detections"),
+           py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>())
       .def("decode_to_errors",
            py::overload_cast<const std::vector<uint64_t>&, size_t, size_t>(
                &TesseractDecoder::decode_to_errors),
-           py::arg("detections"), py::arg("det_order"), py::arg("det_beam"))
+           py::arg("detections"), py::arg("det_order"), py::arg("det_beam"),
+           py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>())
       .def(
           "get_observables_from_errors",
           [](TesseractDecoder& self, const std::vector<size_t>& predicted_errors) {
@@ -100,7 +103,8 @@ void add_tesseract_module(py::module& root) {
             }
             return result;
           },
-          py::arg("detections"))
+          py::arg("detections"),
+          py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>())
       .def_readwrite("low_confidence_flag", &TesseractDecoder::low_confidence_flag)
       .def_readwrite("predicted_errors_buffer", &TesseractDecoder::predicted_errors_buffer)
       .def_readwrite("errors", &TesseractDecoder::errors);


### PR DESCRIPTION
C++'s stdout/stderr and Python's stdout/stderr streams are two different streams.. normally this is not a problem but colab ignores C++'s streams. To make colab see C++'s streams they need to be redirected to Python's streams

if the statement `py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>()` is added to a function's definition then its stdout/stderr gets redirected. I do that for the decoding methods for simplex and tesseract.

so statements like this with `verbose=True` will have their stdout redirected
```py3
>> tesseract_dec.decode(...)
len(pq) = 0 num_pq_pushed = 1
num_detectors = 3 max_num_detectors = 65538 cost = 6.811496946171
activated_errors = 
activated_detectors = 19, 20, 25, 
activated_errors = 880, 
activated_detectors = 
Decoding complete. Cost: 6.811496946171 num_pq_pushed = 100
```


I also added a context manager that can be used to do this from inside python
```py3
import tesseract_decoder
with tesseract_decoder.ostream_redirect(stdout=..., stderr=...):
    # since the call happens inside the context manager its streams get captured  
    a_function_whose_stdout_isnot_redirected()
```