### PR TITLE
Keeps the `stim::DemInstructionType::DEM_LOGICAL_OBSERVABLE` in the dem during processing

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -99,7 +99,7 @@ stim::DetectorErrorModel common::merge_identical_errors(const stim::DetectorErro
         break;
       }
       default:
-        std::cerr << "Unrecognized instruction type: " << instruction.type << std::endl;
+        throw std::invalid_argument("Unrecognized instruction type: " + instruction.str());
     }
   }
   for (const auto& it : errors_by_symptom) {
@@ -127,7 +127,7 @@ stim::DetectorErrorModel common::remove_zero_probability_errors(
         out_dem.append_dem_instruction(instruction);
         break;
       default:
-        std::cerr << "Unrecognized instruction type: " << instruction.type << std::endl;
+        throw std::invalid_argument("Unrecognized instruction type: " + instruction.str());
     }
   }
   return out_dem;
@@ -154,9 +154,6 @@ stim::DetectorErrorModel common::dem_from_counts(stim::DetectorErrorModel& orig_
   size_t ei = 0;
   for (const stim::DemInstruction& instruction : orig_dem.flattened().instructions) {
     switch (instruction.type) {
-      case stim::DemInstructionType::DEM_SHIFT_DETECTORS:
-        assert(false && "unreachable");
-        break;
       case stim::DemInstructionType::DEM_ERROR: {
         double est_probability = double(error_counts.at(ei)) / double(num_shots);
         out_dem.append_error_instruction(est_probability, instruction.target_data, /*tag=*/"");
@@ -172,7 +169,7 @@ stim::DetectorErrorModel common::dem_from_counts(stim::DetectorErrorModel& orig_
         break;
       }
       default:
-        assert(false && "unreachable");
+        throw std::invalid_argument("Unrecognized instruction type: " + instruction.str());
     }
   }
   return out_dem;

--- a/src/common.cc
+++ b/src/common.cc
@@ -94,6 +94,10 @@ stim::DetectorErrorModel common::merge_identical_errors(const stim::DetectorErro
         out_dem.append_dem_instruction(instruction);
         break;
       }
+      case stim::DemInstructionType::DEM_LOGICAL_OBSERVABLE: {
+        out_dem.append_dem_instruction(instruction);
+        break;
+      }
       default:
         std::cerr << "Unrecognized instruction type: " << instruction.type << std::endl;
     }
@@ -117,6 +121,9 @@ stim::DetectorErrorModel common::remove_zero_probability_errors(
         }
         break;
       case stim::DemInstructionType::DEM_DETECTOR:
+        out_dem.append_dem_instruction(instruction);
+        break;
+      case stim::DemInstructionType::DEM_LOGICAL_OBSERVABLE:
         out_dem.append_dem_instruction(instruction);
         break;
       default:
@@ -157,6 +164,10 @@ stim::DetectorErrorModel common::dem_from_counts(stim::DetectorErrorModel& orig_
         break;
       }
       case stim::DemInstructionType::DEM_DETECTOR: {
+        out_dem.append_dem_instruction(instruction);
+        break;
+      }
+      case stim::DemInstructionType::DEM_LOGICAL_OBSERVABLE: {
         out_dem.append_dem_instruction(instruction);
         break;
       }


### PR DESCRIPTION
This ensures that the number of logical observables from `dem.count_observables()` remains correct, even if there `DEM_LOGICAL_OBSERVABLE` observables not triggered by an error.

I also had it throw an exception for unrecognized instructions as we really should be handling all the cases correctly now (and it would be good for the user to know if we're not). Can switch back to cerr if necessary though.