### PR TITLE
Add tesseract-decoder-dev email address to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ cite the following:
 
 ## Contact
 
-For any questions or concerns not addressed here, please email <quantum-oss-maintainers@google.com>.
+For any questions or concerns not addressed here, please email <tesseract-decoder-dev@google.com>.
 
 ## Disclaimer
 


### PR DESCRIPTION
Now that the team has an email address for direct contact, we can use that instead of the generic quantum-oss-maintainers@google.com list as the contact address.