### PR TITLE
Add workflow to label stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,143 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Perform scheduled handling of stale issues and PRs.
+# For info about possible config options, see https://github.com/actions/stale/.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: "Stale issues & PRs handler"
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+  # Allow manual invocation.
+  workflow_dispatch:
+    inputs:
+      debug:
+        # Note: the job body sets `debug-only` to false by default. The value
+        # of inputs.debug is an empty string unless this workflow is invoked
+        # manually. When it's invoked manually, GitHub's GUI presents the user
+        # with a checkbox for this flag. We default that checkbox to true
+        # because the most likely reason for a manual run is debugging.
+        description: 'Run in debug mode (dry run)'
+        type: boolean
+        default: true
+
+env:
+  # Set durations here, to avoid hardcoding them in multiplate places below.
+  days-before-stale: 90
+  days-before-close: 60
+
+  # The syntax for the "actions/stale" GHA uses a comma-separated list, a format
+  # that's hard to read and inconvenient to edit (especially w/ many labels that
+  # use characters such as slash or colon). So instead, we put individual labels
+  # on separate lines here. A job step below converts this to the right form.
+  exempt-issue-labels-list:
+    help wanted
+  exempt-pr-labels-list:
+    health
+
+# Declare default workflow permissions as read only.
+permissions: read-all
+
+jobs:
+  stale:
+    if: github.repository_owner == 'quantumlib'
+    name: Label and/or close stale issues and PRs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+    env:
+      # Setting Bash SHELLOPTS here takes effect for all shell commands below.
+      SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
+    steps:
+    - name: Convert data types
+      id: converted
+      run: |
+        issues=$(echo "${{env.exempt-issue-labels-list}}" | tr ' ' ',')
+        prs=$(echo "${{env.exempt-pr-labels-list}}" | tr ' ' ',')
+        echo "exempt-issue-labels='$issues'" >> "$GITHUB_OUTPUT"
+        echo "exempt-pr-labels='$prs'" >> "$GITHUB_OUTPUT"
+
+    - name: Label and/or close stale issues and/or PRs
+      uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+      with:
+        repo-token: ${{secrets.GITHUB_TOKEN}}
+        debug-only: ${{inputs.debug || false}}
+        days-before-stale: ${{env.days-before-stale}}
+        days-before-close: ${{env.days-before-close}}
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        close-issue-label: 'stale'
+        close-pr-label: 'stale'
+        exempt-issue-labels: ${{steps.converted.outputs.exempt-issue-labels}}
+        exempt-pr-labels: ${{steps.converted.outputs.exempt-pr-labels}}
+        stale-issue-message: >-
+          This issue has been automatically labeled as stale because
+          ${{env.days-before-stale}} days have passed without comments or other
+          activity. If no further activity occurs on this issue and the
+          `status/stale` label is not removed by a maintainer within
+          ${{env.days-before-close}} days, this issue will be closed. If you
+          would like to restore its status, please leave a comment here; doing
+          so will cause the staleness handler to remove the label.
+
+
+          If you have questions or feedback about this process, we welcome your
+          input. You can open a new issue to let us know (please also reference
+          this issue there, for continuity), or reach out to the project
+          maintainers at quantum-oss-maintainers@google.com.
+
+        stale-pr-message: >-
+          This pull request has been automatically labeled as stale because
+          ${{env.days-before-stale}} days have passed without comments or other
+          activity. If no further activity occurs and the `status/stale` label
+          is not removed by a maintainer within ${{env.days-before-close}}
+          days, this pull request will be closed. If you would like to restore
+          its active status, please leave a comment here; doing so will cause
+          the staleness handler to remove the label.
+
+
+          If you have questions or feedback about this process, we welcome your
+          input. You can open a new issue to let us know (please also reference
+          this issue there, for continuity), or reach out to the project
+          maintainers at quantum-oss-maintainers@google.com.
+
+        close-issue-message: >-
+          This issue has been closed due to inactivity for
+          ${{env.days-before-close}} days since the time the `status/stale`
+          label was applied. If you believe the issue is still relevant and
+          would like to restore its active status, please feel free to reopen
+          it.
+
+
+          If you have questions or feedback about this process, we welcome your
+          input. You can open a new issue to let us know (please also reference
+          this issue there, for continuity), or reach out to the project
+          maintainers at quantum-oss-maintainers@google.com.
+
+        close-pr-message: >-
+          This pull request has been closed due to inactivity for
+          ${{env.days-before-close}} days since the time the `status/stale`
+          label was applied. If you would like to continue working on this PR,
+          please feel free to reopen it.
+
+
+          If you have questions or feedback about this process, we welcome your
+          input. You can open a new issue to let us know (please also reference
+          this issue there, for continuity), or reach out to the project
+          maintainers at quantum-oss-maintainers@google.com.


### PR DESCRIPTION
As more and more issues and pull requests start to accumulate, it can be helpful to automatically label stale issues and PRs and automatically close them after a time.

This workflow labels issues with `stale` if the have not had any activity for 90 days or more, and auto-closes them if they have not had any further activity 60 days after that.