### PR TITLE
Update tesseract.perf.cc

### DIFF
--- a/src/tesseract.perf.cc
+++ b/src/tesseract.perf.cc
@@ -28,8 +28,8 @@ void benchmark_decoder(Decoder& decoder, stim::Circuit& circuit, size_t num_shot
   std::vector<stim::SparseShot> shots;
   sample_shots(test_data_seed, circuit, num_shots, shots);
 
-  // Use volatile to try to ensure compiler does not optimize out the decoding
-  volatile size_t total_num_errors_used = 0;
+  // There is no need to use volatile because the cout at the end is a side-effect
+  size_t total_num_errors_used = 0;
   size_t num_low_confidence = 0;
   size_t num_errors = 0;
   size_t num_decoded = 0;


### PR DESCRIPTION
got these warnings building on macos:
```
src/tesseract.perf.cc:51:29: warning: compound assignment to object of volatile-qualified type 'volatile size_t' (aka 'volatile unsigned long') is deprecated [-Wdeprecated-volatile] total_num_errors_used += decoder.predicted_errors_buffer.size(); ^ src/tesseract.perf.cc:87:3: note: in instantiation of function template specialization 'benchmark_decoder<TesseractDecoder>' requested here benchmark_decoder(decoder, circuit, num_shots); ^ src/tesseract.perf.cc:51:29: warning: compound assignment to object of volatile-qualified type 'volatile size_t' (aka 'volatile unsigned long') is deprecated [-Wdeprecated-volatile] total_num_errors_used += decoder.predicted_errors_buffer.size(); ^ src/tesseract.perf.cc:108:3: note: in instantiation of function template specialization 'benchmark_decoder<SimplexDecoder>' requested here benchmark_decoder(decoder, circuit, num_shots); ^ 2 warnings generated. INFO: From Linking src/tesseract_perf:
```

fair enough and we don't need volatile because the cout is a side effect. I sort of wish there were a language feature for not optimizing out variables in C++...