### PR TITLE
Add a Dependabot config file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,7 +25,8 @@ updates:
       - "area/health"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "**/*"
     schedule:
       interval: "monthly"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
This adds a `.github/dependabot.yaml` file for configuring [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) to run on this repo. The configuration makes it check Python and the GitHub Actions used in the CI workflow.

Dependabot regularly looks at the dependencies used in this project (e.g., Python packages) and automatically opens PRs when version updates are available.