### PR TITLE
Revert "Fix section issues gcc 15"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,2 @@
 common --enable_bzlmod --enable_workspace
 build --cxxopt='-std=c++20'
-# Needed to fix issues like this which arose in GCC 15:
-# "error: relocation refers to local symbol [...], which is defined in a discarded section"
-build --copt=-ffunction-sections
-build --copt=-fdata-sections
-build --linkopt=-Wl,--gc-sections


### PR DESCRIPTION
Reverts quantumlib/tesseract-decoder#181
it apparently doesn't build on macos