### PR TITLE
Defer error chain next_node creation

### DIFF
--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -433,13 +433,6 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
       }
       prev_ei = ei;
 
-      // Create the error chain node for this candidate.
-      error_chain_arena.emplace_back();
-      auto& next_node = error_chain_arena.back();
-      next_node.error_index = ei;
-      next_node.min_detector = min_detector;
-      next_node.parent_idx = node.error_chain_idx;
-
       next_detectors = detectors;
       next_detector_cost_tuples[ei].error_blocked = 1;
 
@@ -482,6 +475,13 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
       }
 
       if (next_cost == INF) continue;
+
+      // Create the error chain node for this candidate.
+      error_chain_arena.emplace_back();
+      auto& next_node = error_chain_arena.back();
+      next_node.error_index = ei;
+      next_node.min_detector = min_detector;
+      next_node.parent_idx = node.error_chain_idx;
 
       pq.push({next_cost, next_num_dets, node.depth + 1, (int64_t)(error_chain_arena.size() - 1)});
       ++num_pq_pushed;


### PR DESCRIPTION
Try and optimize arena allloc by deferring it until it is guaranteed to be needed (i.e. since many nodes get pruned by beam, no_revisit_dets, etc. etc. in between)

For context, I am hunting down something that looks like a memory leak right now in Tesseract. This popped up as a possible factor but I have not yet measured the impact on memory (or runtime for that matter). But wanted to get advice on it.