### PR TITLE
Delete decomposer library and test from BUILD

### DIFF
--- a/src/py/BUILD
+++ b/src/py/BUILD
@@ -84,27 +84,6 @@ py_test(
     ],
 )
 
-
-py_library(
-    name = "decomposer",
-    srcs = ["decomposer.py"],
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "@pypi//stim",
-    ],
-)
-
-py_test(
-    name = "decomposer_test",
-    srcs = ["decomposer_test.py"],
-    visibility = ["//:__subpackages__"],
-    deps = [
-        ":decomposer",
-        "@pypi//pytest",
-        "@pypi//stim",
-    ],
-)
-
 compile_pip_requirements(
     name = "requirements",
     src = "requirements.in",


### PR DESCRIPTION
In https://github.com/quantumlib/tesseract-decoder/pull/197 we removed decomposer library and its associated test.

However, that was merged with a failing test because the BUILD did not get updated (sorry!)

Here we remove it from the BUILD