### PR TITLE
Prefer system Boost when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,15 +39,21 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(nlohmann_json)
 
-# Boost headers
-FetchContent_Declare(
-  boost
-  URL https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz
-  URL_HASH SHA256=c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
-)
-FetchContent_MakeAvailable(boost)
-add_library(boost_headers INTERFACE)
-target_include_directories(boost_headers INTERFACE ${boost_SOURCE_DIR})
+# Boost headers - prefer system Boost when available
+find_package(Boost 1.83 QUIET)
+if(Boost_FOUND)
+  add_library(boost_headers INTERFACE)
+  target_link_libraries(boost_headers INTERFACE Boost::boost)
+else()
+  FetchContent_Declare(
+    boost
+    URL https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz
+    URL_HASH SHA256=c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
+  )
+  FetchContent_MakeAvailable(boost)
+  add_library(boost_headers INTERFACE)
+  target_include_directories(boost_headers INTERFACE ${boost_SOURCE_DIR})
+endif()
 
 # pybind11
 FetchContent_Declare(


### PR DESCRIPTION
Benefits:

- Avoids the > 100MB download when system Boost is available
- Reduces NFS traffic and disk usage in shared environments

Falls back quietly to FetchContent if system Boost is unavailable