### PR TITLE
Cleanup OPT_COPTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 
-set(OPT_COPTS -Ofast -fno-fast-math -march=native)
+set(OPT_COPTS -O3 -march=native)
 
 set(TESSERACT_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 


### PR DESCRIPTION
-Ofast -fno-fast-math is the same as plain old -O3 as far as I understand. Unless, this is a trick to achieve more inlining?

This change also silences the clang warnings about deprecated -Ofast