### PR TITLE
fix `strip_undecomposable_errors` flag in `decompose_errors`.

### DIFF
--- a/src/py/_tesseract_py_util/decompose_errors.py
+++ b/src/py/_tesseract_py_util/decompose_errors.py
@@ -185,6 +185,8 @@ def decompose_errors_using_detector_assignment(
         )
 
         if consistent_obs_by_component is None:
+            if strip_undecomposable_errors:
+                continue
             raise ValueError(
                 f"The error instruction `{instruction}` could not be decomposed, due to its "
                 "observables not being consistent with the observables of any available "

--- a/src/py/_tesseract_py_util/decompose_errors_test.py
+++ b/src/py/_tesseract_py_util/decompose_errors_test.py
@@ -211,6 +211,34 @@ error(0.1) D0
     assert str(decomposed_dem) == str(expected_dem)
 
 
+
+
+def test_decompose_errors_strip_inconsistent_observables():
+    dem = stim.DetectorErrorModel("""
+detector(0) D0
+detector(1) D1
+# Standalone components fix observable choices for each detector.
+error(0.1) D0 L0
+error(0.1) D1 L1
+# Cross-component error has observables that cannot be matched by available components.
+error(0.1) D0 D1 L0
+""")
+
+    with pytest.raises(ValueError, match="could not be decomposed"):
+        decompose_errors_using_last_coordinate_index(dem)
+
+    decomposed_dem = decompose_errors_using_last_coordinate_index(
+        dem, strip_undecomposable_errors=True
+    )
+
+    expected_dem = stim.DetectorErrorModel("""
+detector(0) D0
+detector(1) D1
+error(0.1) D0 L0
+error(0.1) D1 L1
+""")
+    assert str(decomposed_dem) == str(expected_dem)
+
 def test_undecompose_errors_with_repeat_block():
     dem = stim.DetectorErrorModel("""error(0.1) D2 D5 ^ D10 L1
 repeat 10 {


### PR DESCRIPTION
Decompose errors still fails on logically inconsistent errors because I forgot to bypass that valueerror, adding it here.