### PR TITLE
fix bug in detcost computation

### DIFF
--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -88,26 +88,26 @@ bool Node::operator>(const Node& other) const {
 double TesseractDecoder::get_detcost(
     size_t d, const std::vector<DetectorCostTuple>& detector_cost_tuples) const {
   double min_cost = INF;
-  uint32_t min_det_cost = std::numeric_limits<uint32_t>::max();
+  uint32_t min_det_cost_det_count = std::numeric_limits<uint32_t>::max();
   double error_cost;
   ErrorCost ec;
   DetectorCostTuple dct;
 
   for (int ei : d2e[d]) {
     ec = error_costs[ei];
-    if (ec.likelihood_cost * min_det_cost >= min_cost * errors[ei].symptom.detectors.size()) break;
+    if (ec.likelihood_cost * min_det_cost_det_count >= min_cost * errors[ei].symptom.detectors.size()) break;
 
     dct = detector_cost_tuples[ei];
     if (!dct.error_blocked) {
       error_cost = ec.likelihood_cost;
-      if (error_cost < min_cost * dct.detectors_count) {
+      if (error_cost * min_det_cost_det_count < min_cost * dct.detectors_count) {
         min_cost = error_cost;
-        min_det_cost = dct.detectors_count;
+        min_det_cost_det_count = dct.detectors_count;
       }
     }
   }
 
-  return (min_cost / min_det_cost) + config.det_penalty;
+  return (min_cost / min_det_cost_det_count) + config.det_penalty;
 }
 
 TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(config_) {

--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -108,7 +108,6 @@ struct TesseractDecoder {
     return eneighbors;
   }
 
- private:
   std::vector<std::vector<int>> d2e;
   std::vector<std::vector<int>> eneighbors;
   std::vector<std::vector<int>> edets;

--- a/src/tesseract.test.cc
+++ b/src/tesseract.test.cc
@@ -395,3 +395,26 @@ TEST(tesseract, DecodeToErrorsThrowsOnInvalidSymptom) {
               err.what());
   }
 }
+
+TEST(TesseractDetcostTest, ComparesRatiosNotRawCosts) {
+  stim::DetectorErrorModel dem = stim::DetectorErrorModel(R"DEM(
+    error(0.005322067133022559) D0 D1 D3
+    error(0.0051237598826648) D0 D1 D2
+  )DEM");
+
+  TesseractConfig cfg;
+  cfg.dem = dem;
+  cfg.merge_errors = false;
+  TesseractDecoder dec(cfg);
+
+  std::vector<DetectorCostTuple> tuples(dec.errors.size());
+  // residual x = {D0, D1}
+  std::cout <<"dec.d2e.size() = "<<dec.d2e.size()<<std::endl;
+  for (int ei : dec.d2e[0]) tuples[ei].detectors_count++;
+  for (int ei : dec.d2e[1]) tuples[ei].detectors_count++;
+
+  double got = dec.get_detcost(0, tuples);
+  double expected = 5.230557212477344 / 2.0;  // from D0 D1 D3
+
+  EXPECT_NEAR(got, expected, 1e-12);
+}


### PR DESCRIPTION
This fixes https://github.com/quantumlib/tesseract-decoder/issues/226 by correcting the detcost computation.