### PR TITLE
Reduce number of Dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -32,7 +32,7 @@ updates:
       - dependency-name: sinter
       - dependency-name: pybind11-stubgen
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     versioning-strategy: "increase-if-necessary"
     groups:
       python-dependencies:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,11 +25,19 @@ updates:
       - "area/health"
 
   - package-ecosystem: "pip"
-    directories:
-      - "**/*"
+    directory: "/src/py"
+    allow:
+      - dependency-name: stim
+      - dependency-name: pytest
+      - dependency-name: sinter
+      - dependency-name: pybind11-stubgen
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     versioning-strategy: "increase-if-necessary"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
     labels:
       - "area/dependencies"
       - "area/python"

--- a/src/py/requirements.in
+++ b/src/py/requirements.in
@@ -1,3 +1,6 @@
+# Note: if you add or subtract from the list below, also update the "allow"
+# list in ../../.github/dependabot.yaml.
+
 stim
 pytest
 sinter


### PR DESCRIPTION
This changes 2 things:

- Enable grouped updates. Instead of a separate PR for every package,
  Dependabot can combine them into a single "dependency update" PR.

- Limit to direct dependencies. We can use the allow key to restrict it
  to only the packages you explicitly list in the `requirements.in`.