### PR TITLE
docs: document CMake build path and macOS case-insensitive-FS collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ Tesseract uses [Bazel](https://bazel.build/) as its build system. To build the d
 bazel build src:all
 ```
 
+#### Building with CMake
+
+Tesseract also ships a `CMakeLists.txt` that vendors all C++ dependencies (Stim, HiGHS, argparse, nlohmann/json, Boost) via `FetchContent` for a single self-contained build:
+
+```bash
+cmake -S . -B cmake-build -DCMAKE_BUILD_TYPE=Release
+cmake --build cmake-build -j
+# Binary: cmake-build/tesseract
+```
+
+> **Note for macOS / Windows users.** The conventional CMake binary directory name is `build`, but the Bazel build descriptor at the repository root is named `BUILD` (uppercase). On case-insensitive filesystems — APFS (macOS default) and NTFS (Windows default) — `cmake -B build` fails with `Error: <repo>/BUILD is not a directory` because CMake cannot create a directory whose name collides with the existing `BUILD` regular file. Use a non-conflicting name (for example `cmake-build`, `_build`, or `out`) as shown above. On case-sensitive filesystems (typical Linux ext4 / xfs) `cmake -B build` works without modification.
+
 ## Running Tests
 
 Unit tests are executed with Bazel. Run the quick test suite using:


### PR DESCRIPTION
## Summary

Documents the CMake build path (currently undocumented despite a working `CMakeLists.txt` shipping at the repository root) and explicitly calls out a deterministic build failure on case-insensitive filesystems — APFS (macOS default) and NTFS (Windows default) — caused by a name collision between the conventional CMake binary directory `build/` and the Bazel `BUILD` descriptor at the repository root.

## Motivation

A user on macOS following the conventional CMake invocation `cmake -B build` encounters:

```
CMake Error: Unable to (re)create the private pkgRedirects directory:
  <repo>/BUILD/CMakeFiles/pkgRedirects
This may be caused by not having read/write access to the build directory.
Try specifying a location with read/write access like:
  cmake -B build
If using a CMake presets file, ensure that preset parameter
'binaryDir' expands to a writable directory.

Error: <repo>/BUILD is not a directory
```

This is deterministic on default-configured macOS APFS volumes (case-insensitive by default; verifiable via `diskutil info /`, which reports the volume's `Case-sensitive` property). The same invocation succeeds on case-sensitive Linux ext4/xfs because `BUILD` (file) and `build/` (directory) are distinct names there.

The README currently documents only `bazel build src:all`; no CMake instructions are provided despite `CMakeLists.txt` being a fully functional alternative that vendors Stim, HiGHS, argparse, nlohmann/json, and Boost via `FetchContent`.

## Changes

`README.md` § "Build Instructions": adds a new `#### Building with CMake` subsection (~15 lines) with the CMake invocation (using `-B cmake-build` to avoid the collision) and a `> **Note**` callout explaining the macOS/Windows filesystem-collision failure mode and the workaround.

No code changes; documentation only.

## Reproduction

```bash
git clone https://github.com/quantumlib/tesseract-decoder.git
cd tesseract-decoder

# FAILS on case-insensitive FS (macOS APFS default, Windows NTFS default):
cmake -B build -DCMAKE_BUILD_TYPE=Release

# SUCCEEDS on the same machine:
cmake -B cmake-build -DCMAKE_BUILD_TYPE=Release
cmake --build cmake-build -j
ls -lh cmake-build/tesseract
```

## Bazel ecosystem precedent

Bazel officially supports both `BUILD` and `BUILD.bazel` as valid build-descriptor filenames (per the Bazel project's documentation at bazel.build). One project in the Bazel ecosystem already using `BUILD.bazel` to avoid filesystem collisions of this class is `nlohmann/json`, which is a transitive dependency of this repository's CMake build (visible at `cmake-build/_deps/nlohmann_json-src/BUILD.bazel` after the CMake `FetchContent` step).

## Scope

This PR is intentionally scoped to **documentation only**. A more comprehensive fix renaming `BUILD` → `BUILD.bazel` (the canonical Bazel-ecosystem solution to this exact collision class) requires additionally updating the literal `BUILD` references in:

- `.github/workflows/prerelease.yml` (lines ~84, ~141): `sed "s/^MANYLINUX_VERSION.*/.../" BUILD -i`
- `.github/workflows/stable-release-workflow.yml` (line ~84): same `sed` pattern
- `AGENTS.md` (line ~47): doc reference to "the `BUILD` file"

Such a rename can be tracked as a separate follow-up PR if maintainers prefer the canonical-rename approach. This PR documents existing behavior and provides an immediate workaround without altering CI or release workflows.

## Test plan

- [ ] `cmake -B cmake-build -DCMAKE_BUILD_TYPE=Release && cmake --build cmake-build -j` succeeds on macOS (Apple Silicon, default APFS case-insensitive).
- [ ] `cmake -B build -DCMAKE_BUILD_TYPE=Release` reproduces the documented failure on the same machine.
- [ ] README markdown renders correctly in GitHub preview.



Disclaimer: I am an independent researcher and this work is in no relation to or sponsored by my current employer or current role with that employer, it has been completed on my own time and on my own hardware.