### PR TITLE
Add sparsify errors nano-tutorial to the ipynb docs via Jupytext template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
         brew install clang-format
 
     - name: Bazel tests
-      run: bazel test --jobs=1 src/... //docs:tutorial_jupytext_sync_test
+      run: bazel test src/... //docs:tutorial_jupytext_sync_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
         brew install clang-format
 
     - name: Bazel tests
-      run: bazel test src/...
+      run: bazel test --jobs=1 src/... //docs:tutorial_jupytext_sync_test

--- a/docs/sync_tutorial_notebook.py
+++ b/docs/sync_tutorial_notebook.py
@@ -16,13 +16,11 @@
 
 import argparse
 import difflib
-import json
 import os
 from pathlib import Path
-import shutil
 import sys
-import tempfile
 
+from jupytext import read, writes
 from jupytext.cli import jupytext
 
 FORMATS = "ipynb,py:percent"
@@ -71,12 +69,8 @@ def _write_notebook_from_source(root: Path) -> None:
     )
 
 
-def _canonical_json(path: Path) -> list[str]:
-    return json.dumps(
-        json.loads(path.read_text()),
-        indent=2,
-        sort_keys=True,
-    ).splitlines(keepends=True)
+def _canonical_source(path: Path) -> list[str]:
+    return writes(read(path), fmt="py:percent").splitlines(keepends=True)
 
 
 def _check_pair() -> int:
@@ -88,31 +82,22 @@ def _check_pair() -> int:
         sys.stderr.write(f"{SOURCE_PATH} is missing; run `bazel run //docs:sync_tutorial_notebook -- --write`.\n")
         return 1
 
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_root = Path(tmp)
-        tmp_docs = tmp_root / "docs"
-        tmp_docs.mkdir()
-        shutil.copy2(source, tmp_docs / SOURCE_PATH.name)
-        shutil.copy2(notebook, tmp_docs / NOTEBOOK_PATH.name)
-
-        _write_notebook_from_source(tmp_root)
-
-        expected = _canonical_json(notebook)
-        actual = _canonical_json(tmp_docs / NOTEBOOK_PATH.name)
-        if expected != actual:
-            sys.stderr.write(
-                f"{NOTEBOOK_PATH} is not synchronized with {SOURCE_PATH}. "
-                "Run `bazel run //docs:sync_tutorial_notebook -- --write`.\n"
+    expected = _canonical_source(source)
+    actual = _canonical_source(notebook)
+    if expected != actual:
+        sys.stderr.write(
+            f"{NOTEBOOK_PATH} is not synchronized with {SOURCE_PATH}. "
+            "Run `bazel run //docs:sync_tutorial_notebook -- --write`.\n"
+        )
+        sys.stderr.writelines(
+            difflib.unified_diff(
+                expected,
+                actual,
+                fromfile=str(SOURCE_PATH),
+                tofile=f"{NOTEBOOK_PATH} as py:percent",
             )
-            sys.stderr.writelines(
-                difflib.unified_diff(
-                    expected,
-                    actual,
-                    fromfile=str(NOTEBOOK_PATH),
-                    tofile="generated tutorial.ipynb",
-                )
-            )
-            return 1
+        )
+        return 1
 
     return 0
 

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -668,7 +668,9 @@
     {
       "cell_type": "markdown",
       "id": "cf7a81ad",
-      "metadata": {},
+      "metadata": {
+        "id": "cf7a81ad"
+      },
       "source": [
         "## Sparsify errors\n",
         "\n",
@@ -687,7 +689,9 @@
       "cell_type": "code",
       "execution_count": null,
       "id": "dd61010b",
-      "metadata": {},
+      "metadata": {
+        "id": "dd61010b"
+      },
       "outputs": [],
       "source": [
         "sparse_config = tesseract.TesseractConfig(\n",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -680,7 +680,7 @@
         "| --- | ---: |\n",
         "| Surface / graphlike | `2` |\n",
         "| Color / bivariate bicycle | `3` |\n",
-        "| Other | bulk single-error detector degree |"
+        "| Other | bulk single-qubit-X-error detector degree |"
       ]
     },
     {

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -603,43 +603,6 @@
     },
     {
       "cell_type": "markdown",
-      "id": "cf7a81ad",
-      "metadata": {},
-      "source": [
-        "## Sparsify errors\n",
-        "\n",
-        "Keep common low-degree errors hot; activate likely high-degree errors per shot.\n",
-        "[Benchmarks and plots](https://github.com/quantumlib/tesseract-decoder/pull/254) show roughly a\n",
-        "**10x speedup with little change to logical error rate (LER)**.\n",
-        "\n",
-        "| DEM | Base degree |\n",
-        "| --- | ---: |\n",
-        "| Surface / graphlike | `2` |\n",
-        "| Color / bivariate bicycle | `3` |\n",
-        "| Other | bulk single-error detector degree |"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "dd61010b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "sparse_config = tesseract.TesseractConfig(\n",
-        "    dem=dem,\n",
-        "    pqlimit=10000,\n",
-        "    no_revisit_dets=True,\n",
-        "    sparsify_errors=True,\n",
-        "    sparsify_base_degree=3,\n",
-        "    sparsify_reactivate_limit=-1,  # Auto-tune.\n",
-        ")\n",
-        "results = run_tesseract_decoder(sparse_config.compile_decoder(), dets, obs)\n",
-        "print_results(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
       "metadata": {
         "id": "INvMKs7zc5T_"
       },
@@ -700,6 +663,43 @@
         "\n",
         "* `pqlimit` - An integer that sets a limit on the number of nodes in the priority queue. This can be used to constrain the memory usage of the decoder. The default value is `sys.maxsize`, which means the size is effectively unbounded.\n",
         "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cf7a81ad",
+      "metadata": {},
+      "source": [
+        "## Sparsify errors\n",
+        "\n",
+        "Keep common low-degree errors hot; activate likely high-degree errors per shot.\n",
+        "[Benchmarks and plots](https://github.com/quantumlib/tesseract-decoder/pull/254) show roughly a\n",
+        "**10x speedup with little change to logical error rate (LER)**.\n",
+        "\n",
+        "| DEM | Base degree |\n",
+        "| --- | ---: |\n",
+        "| Surface / graphlike | `2` |\n",
+        "| Color / bivariate bicycle | `3` |\n",
+        "| Other | bulk single-error detector degree |"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "dd61010b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "sparse_config = tesseract.TesseractConfig(\n",
+        "    dem=dem,\n",
+        "    pqlimit=10000,\n",
+        "    no_revisit_dets=True,\n",
+        "    sparsify_errors=True,\n",
+        "    sparsify_base_degree=3,\n",
+        "    sparsify_reactivate_limit=-1,  # Auto-tune.\n",
+        ")\n",
+        "results = run_tesseract_decoder(sparse_config.compile_decoder(), dets, obs)\n",
+        "print_results(results)"
       ]
     },
     {

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -603,6 +603,43 @@
     },
     {
       "cell_type": "markdown",
+      "id": "cf7a81ad",
+      "metadata": {},
+      "source": [
+        "## Sparsify errors\n",
+        "\n",
+        "Keep common low-degree errors hot; activate likely high-degree errors per shot.\n",
+        "[Benchmarks and plots](https://github.com/quantumlib/tesseract-decoder/pull/254) show roughly a\n",
+        "**10x speedup with little change to logical error rate (LER)**.\n",
+        "\n",
+        "| DEM | Base degree |\n",
+        "| --- | ---: |\n",
+        "| Surface / graphlike | `2` |\n",
+        "| Color / bivariate bicycle | `3` |\n",
+        "| Other | bulk single-error detector degree |"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "dd61010b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "sparse_config = tesseract.TesseractConfig(\n",
+        "    dem=dem,\n",
+        "    pqlimit=10000,\n",
+        "    no_revisit_dets=True,\n",
+        "    sparsify_errors=True,\n",
+        "    sparsify_base_degree=3,\n",
+        "    sparsify_reactivate_limit=-1,  # Auto-tune.\n",
+        ")\n",
+        "results = run_tesseract_decoder(sparse_config.compile_decoder(), dets, obs)\n",
+        "print_results(results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "INvMKs7zc5T_"
       },

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -667,7 +667,6 @@
     },
     {
       "cell_type": "markdown",
-      "id": "cf7a81ad",
       "metadata": {
         "id": "cf7a81ad"
       },
@@ -688,7 +687,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "dd61010b",
       "metadata": {
         "id": "dd61010b"
       },

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -215,7 +215,7 @@ print(f"   Number of Errors / num_shots: {num_errors} / {num_shots_to_decode}")
 #
 #
 
-# %% [markdown]
+# %% [markdown] id="cf7a81ad"
 # ## Sparsify errors
 #
 # Keep common low-degree errors hot; activate likely high-degree errors per shot.
@@ -228,7 +228,7 @@ print(f"   Number of Errors / num_shots: {num_errors} / {num_shots_to_decode}")
 # | Color / bivariate bicycle | `3` |
 # | Other | bulk single-qubit-X-error detector degree |
 
-# %%
+# %% id="dd61010b"
 sparse_config = tesseract.TesseractConfig(
     dem=dem,
     pqlimit=10000,

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -185,31 +185,6 @@ tesseract_dec = tesseract_config.compile_decoder()
 results = run_tesseract_decoder(tesseract_dec, dets, obs)
 print_results(results)
 
-# %% [markdown]
-# ## Sparsify errors
-#
-# Keep common low-degree errors hot; activate likely high-degree errors per shot.
-# [Benchmarks and plots](https://github.com/quantumlib/tesseract-decoder/pull/254) show roughly a
-# **10x speedup with little change to logical error rate (LER)**.
-#
-# | DEM | Base degree |
-# | --- | ---: |
-# | Surface / graphlike | `2` |
-# | Color / bivariate bicycle | `3` |
-# | Other | bulk single-error detector degree |
-
-# %%
-sparse_config = tesseract.TesseractConfig(
-    dem=dem,
-    pqlimit=10000,
-    no_revisit_dets=True,
-    sparsify_errors=True,
-    sparsify_base_degree=3,
-    sparsify_reactivate_limit=-1,  # Auto-tune.
-)
-results = run_tesseract_decoder(sparse_config.compile_decoder(), dets, obs)
-print_results(results)
-
 # %% [markdown] id="INvMKs7zc5T_"
 # #Decoding with ILP decoder
 
@@ -239,6 +214,31 @@ print(f"   Number of Errors / num_shots: {num_errors} / {num_shots_to_decode}")
 # * `pqlimit` - An integer that sets a limit on the number of nodes in the priority queue. This can be used to constrain the memory usage of the decoder. The default value is `sys.maxsize`, which means the size is effectively unbounded.
 #
 #
+
+# %% [markdown]
+# ## Sparsify errors
+#
+# Keep common low-degree errors hot; activate likely high-degree errors per shot.
+# [Benchmarks and plots](https://github.com/quantumlib/tesseract-decoder/pull/254) show roughly a
+# **10x speedup with little change to logical error rate (LER)**.
+#
+# | DEM | Base degree |
+# | --- | ---: |
+# | Surface / graphlike | `2` |
+# | Color / bivariate bicycle | `3` |
+# | Other | bulk single-error detector degree |
+
+# %%
+sparse_config = tesseract.TesseractConfig(
+    dem=dem,
+    pqlimit=10000,
+    no_revisit_dets=True,
+    sparsify_errors=True,
+    sparsify_base_degree=3,
+    sparsify_reactivate_limit=-1,  # Auto-tune.
+)
+results = run_tesseract_decoder(sparse_config.compile_decoder(), dets, obs)
+print_results(results)
 
 # %% colab={"base_uri": "https://localhost:8080/"} id="0pExdmuPQuGr" outputId="8e8ff3fd-bde9-4e31-d1e2-4f97c77ce43d"
 tesseract_config1 = tesseract.TesseractConfig(

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -226,7 +226,7 @@ print(f"   Number of Errors / num_shots: {num_errors} / {num_shots_to_decode}")
 # | --- | ---: |
 # | Surface / graphlike | `2` |
 # | Color / bivariate bicycle | `3` |
-# | Other | bulk single-error detector degree |
+# | Other | bulk single-qubit-X-error detector degree |
 
 # %%
 sparse_config = tesseract.TesseractConfig(

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -185,6 +185,31 @@ tesseract_dec = tesseract_config.compile_decoder()
 results = run_tesseract_decoder(tesseract_dec, dets, obs)
 print_results(results)
 
+# %% [markdown]
+# ## Sparsify errors
+#
+# Keep common low-degree errors hot; activate likely high-degree errors per shot.
+# [Benchmarks and plots](https://github.com/quantumlib/tesseract-decoder/pull/254) show roughly a
+# **10x speedup with little change to logical error rate (LER)**.
+#
+# | DEM | Base degree |
+# | --- | ---: |
+# | Surface / graphlike | `2` |
+# | Color / bivariate bicycle | `3` |
+# | Other | bulk single-error detector degree |
+
+# %%
+sparse_config = tesseract.TesseractConfig(
+    dem=dem,
+    pqlimit=10000,
+    no_revisit_dets=True,
+    sparsify_errors=True,
+    sparsify_base_degree=3,
+    sparsify_reactivate_limit=-1,  # Auto-tune.
+)
+results = run_tesseract_decoder(sparse_config.compile_decoder(), dets, obs)
+print_results(results)
+
 # %% [markdown] id="INvMKs7zc5T_"
 # #Decoding with ILP decoder
 


### PR DESCRIPTION
In https://github.com/quantumlib/tesseract-decoder/pull/254 and https://github.com/quantumlib/tesseract-decoder/pull/257 we added error sparsification which gives a big adjustable speedup (maybe roughly 10x) without hurting LER much. But it's not in our ipynb docs. In https://github.com/quantumlib/tesseract-decoder/pull/261 we switched our ipynb to be generated via juyptext, which makes it easier to update it.

So here we add a small explanation of the sparsify errors feature to the docs notebook.

We also add a 1-line change to the CI to validate that the ipynb file is in-sync with the jupytext template.