### PR TITLE
update pybind11 version to be compatible with python13

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_python", version = "1.9.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
-bazel_dep(name = "pybind11_bazel", version = "2.13.6")
+bazel_dep(name = "pybind11_bazel", version = "3.0.1")
 
 DEFAULT_PYTHON_VERSION = "3.13"
 


### PR DESCRIPTION
older pybind11 use a function that was removed in python13 which causes the error `undefined symbol: _PyThreadState_UncheckedGet`