### PR TITLE
Parametrize Bazel `disk-cache` by `matrix.os`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}
+        disk-cache: ${{ github.workflow }}-${{ matrix.os }}
         repository-cache: true
 
     - name: Install clang-format (Linux)

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -68,7 +68,7 @@ jobs:
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}
+        disk-cache: ${{ github.workflow }}-${{ matrix.os }}-py${{ matrix.python-version }}
         repository-cache: true
 
     - name: Set Python Version

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -68,7 +68,7 @@ jobs:
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}
+        disk-cache: ${{ github.workflow }}-${{ matrix.os }}-py${{ matrix.python-version }}
         repository-cache: true
 
     - name: Set Python Version


### PR DESCRIPTION
The Bazel disk cache should probably be scoped by the `matrix.os` value and the Python version in matrix jobs. This observation was spurred by https://github.com/quantumlib/tesseract-decoder/pull/277#issuecomment-5229263559, although it is not yet clear whether narrowing the scope will in fact fix the failure in that PR.