### PR TITLE
Fix portable wheel builds and validate wheels in PR CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,14 @@ build --cxxopt='-std=c++20'
 # native CPU tuning in //src:OPT_COPTS.
 build:wheel --define=tesseract_portable_wheel=true
 
+# macOS arm64 wheels are tagged macosx_11_0. Apply the deployment target to
+# every build action, including external dependencies and final link actions.
+build:macos_wheel --action_env=MACOSX_DEPLOYMENT_TARGET=11.0
+build:macos_wheel --host_action_env=MACOSX_DEPLOYMENT_TARGET=11.0
+build:macos_wheel --repo_env=MACOSX_DEPLOYMENT_TARGET=11.0
+build:macos_wheel --copt=-mmacosx-version-min=11.0
+build:macos_wheel --linkopt=-mmacosx-version-min=11.0
+
 # Needed to fix issues like this which arose in GCC 15 on Linux:
 # "error: relocation refers to local symbol [...], which is defined in a discarded section"
 # We keep it linux-only so macos does not receive GNU ld flags

--- a/.bazelrc
+++ b/.bazelrc
@@ -9,13 +9,21 @@ build --cxxopt='-std=c++20'
 # native CPU tuning in //src:OPT_COPTS.
 build:wheel --define=tesseract_portable_wheel=true
 
-# macOS arm64 wheels are tagged macosx_11_0. Apply the deployment target to
-# every build action, including external dependencies and final link actions.
-build:macos_wheel --action_env=MACOSX_DEPLOYMENT_TARGET=11.0
-build:macos_wheel --host_action_env=MACOSX_DEPLOYMENT_TARGET=11.0
-build:macos_wheel --repo_env=MACOSX_DEPLOYMENT_TARGET=11.0
-build:macos_wheel --copt=-mmacosx-version-min=11.0
-build:macos_wheel --linkopt=-mmacosx-version-min=11.0
+# macOS wheels enforce the deployment target matching their platform tag:
+# arm64 wheels are tagged macosx_11_0 and x86-64 wheels macosx_10_15. Apply
+# each deployment target to every build action, including external
+# dependencies and final link actions.
+build:macos_arm64_wheel --action_env=MACOSX_DEPLOYMENT_TARGET=11.0
+build:macos_arm64_wheel --host_action_env=MACOSX_DEPLOYMENT_TARGET=11.0
+build:macos_arm64_wheel --repo_env=MACOSX_DEPLOYMENT_TARGET=11.0
+build:macos_arm64_wheel --copt=-mmacosx-version-min=11.0
+build:macos_arm64_wheel --linkopt=-mmacosx-version-min=11.0
+
+build:macos_x86_64_wheel --action_env=MACOSX_DEPLOYMENT_TARGET=10.15
+build:macos_x86_64_wheel --host_action_env=MACOSX_DEPLOYMENT_TARGET=10.15
+build:macos_x86_64_wheel --repo_env=MACOSX_DEPLOYMENT_TARGET=10.15
+build:macos_x86_64_wheel --copt=-mmacosx-version-min=10.15
+build:macos_x86_64_wheel --linkopt=-mmacosx-version-min=10.15
 
 # Needed to fix issues like this which arose in GCC 15 on Linux:
 # "error: relocation refers to local symbol [...], which is defined in a discarded section"

--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,10 @@ common --enable_platform_specific_config
 
 build --cxxopt='-std=c++20'
 
+# Public Linux wheels use a portable x86-64 baseline. Normal builds retain the
+# native CPU tuning in //src:OPT_COPTS.
+build:wheel --define=tesseract_portable_wheel=true
+
 # Needed to fix issues like this which arose in GCC 15 on Linux:
 # "error: relocation refers to local symbol [...], which is defined in a discarded section"
 # We keep it linux-only so macos does not receive GNU ld flags

--- a/.bazelrc
+++ b/.bazelrc
@@ -9,21 +9,14 @@ build --cxxopt='-std=c++20'
 # native CPU tuning in //src:OPT_COPTS.
 build:wheel --define=tesseract_portable_wheel=true
 
-# macOS wheels enforce the deployment target matching their platform tag:
-# arm64 wheels are tagged macosx_11_0 and x86-64 wheels macosx_10_15. Apply
-# each deployment target to every build action, including external
-# dependencies and final link actions.
+# Published macOS wheels are arm64-only and tagged macosx_11_0. Apply the
+# deployment target to every build action, including external dependencies
+# and final link actions.
 build:macos_arm64_wheel --action_env=MACOSX_DEPLOYMENT_TARGET=11.0
 build:macos_arm64_wheel --host_action_env=MACOSX_DEPLOYMENT_TARGET=11.0
 build:macos_arm64_wheel --repo_env=MACOSX_DEPLOYMENT_TARGET=11.0
 build:macos_arm64_wheel --copt=-mmacosx-version-min=11.0
 build:macos_arm64_wheel --linkopt=-mmacosx-version-min=11.0
-
-build:macos_x86_64_wheel --action_env=MACOSX_DEPLOYMENT_TARGET=10.15
-build:macos_x86_64_wheel --host_action_env=MACOSX_DEPLOYMENT_TARGET=10.15
-build:macos_x86_64_wheel --repo_env=MACOSX_DEPLOYMENT_TARGET=10.15
-build:macos_x86_64_wheel --copt=-mmacosx-version-min=10.15
-build:macos_x86_64_wheel --linkopt=-mmacosx-version-min=10.15
 
 # Needed to fix issues like this which arose in GCC 15 on Linux:
 # "error: relocation refers to local symbol [...], which is defined in a discarded section"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,167 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build distribution wheels
+
+# Builds, repairs, installs, and imports distribution wheels.
+# This reusable workflow never publishes packages and receives no
+# PyPI secrets.
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      upload_artifacts:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build_linux_wheels:
+    name: Linux wheels (${{ matrix.python-version }})
+    runs-on: ubuntu-24.04
+    container: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - python-version: '3.11'
+            python-abi: cp311-cp311
+            target-version: cp311
+          - python-version: '3.12'
+            python-abi: cp312-cp312
+            target-version: cp312
+          - python-version: '3.13'
+            python-abi: cp313-cp313
+            target-version: cp313
+    env:
+      PYTHON_BIN: /opt/python/${{ matrix.python-abi }}/bin/python
+      TARGET_PYTHON: ${{ matrix.python-version }}
+      TARGET_VERSION: ${{ matrix.target-version }}
+      VERSION: ${{ inputs.version }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up Bazel
+      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      with:
+        bazelisk-version: 1.29.0
+        bazelisk-cache: true
+        repository-cache: true
+
+    - name: Build, repair, and validate Linux wheel
+      run: |
+        export PATH="$(dirname "$PYTHON_BIN"):$PATH"
+        python _update_bazel_py_version.py "$TARGET_PYTHON"
+        bazel build --jobs=1 --config=wheel \
+          --define TARGET_VERSION="$TARGET_VERSION" \
+          --define VERSION="$VERSION" \
+          :tesseract_decoder_wheel
+        mkdir -p wheelhouse
+        auditwheel repair \
+          --plat manylinux_2_28_x86_64 \
+          bazel-bin/*.whl \
+          --wheel-dir wheelhouse
+        auditwheel show wheelhouse/*.whl
+        "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
+        /tmp/tesseract-wheel-test/bin/python -m pip install \
+          --only-binary=:all: \
+          wheelhouse/*.whl
+        (
+          cd /tmp
+          /tmp/tesseract-wheel-test/bin/python - <<'PY'
+        import tesseract_decoder
+        from tesseract_decoder import demutil
+
+        print(tesseract_decoder.__file__)
+        print("wheel import passed")
+        PY
+        )
+
+    - name: Upload Linux wheel
+      if: inputs.upload_artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: python-wheels-linux-${{ matrix.python-version }}
+        path: wheelhouse/*.whl
+
+  build_macos_wheels:
+    name: macOS wheels (${{ matrix.python-version }})
+    runs-on: macos-14
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - python-version: '3.11'
+            target-version: cp311
+          - python-version: '3.12'
+            target-version: cp312
+          - python-version: '3.13'
+            target-version: cp313
+    env:
+      TARGET_PYTHON: ${{ matrix.python-version }}
+      TARGET_VERSION: ${{ matrix.target-version }}
+      VERSION: ${{ inputs.version }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set up Bazel
+      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      with:
+        bazelisk-cache: true
+        repository-cache: true
+
+    - name: Build and validate macOS wheel
+      run: |
+        python _update_bazel_py_version.py "$TARGET_PYTHON"
+        bazel build --jobs=1 --config=wheel \
+          --define TARGET_VERSION="$TARGET_VERSION" \
+          --define VERSION="$VERSION" \
+          :tesseract_decoder_wheel
+        mkdir -p wheelhouse
+        cp bazel-bin/*.whl wheelhouse/
+        python -m venv /tmp/tesseract-wheel-test
+        /tmp/tesseract-wheel-test/bin/python -m pip install \
+          --only-binary=:all: \
+          wheelhouse/*.whl
+        (
+          cd /tmp
+          /tmp/tesseract-wheel-test/bin/python - <<'PY'
+        import tesseract_decoder
+        from tesseract_decoder import demutil
+
+        print(tesseract_decoder.__file__)
+        print("wheel import passed")
+        PY
+        )
+
+    - name: Upload macOS wheel
+      if: inputs.upload_artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: python-wheels-macos-${{ matrix.python-version }}
+        path: wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -103,50 +103,20 @@ jobs:
         path: wheelhouse/*.whl
 
   build_macos_wheels:
-    name: macOS ${{ matrix.architecture }} wheels (${{ matrix.python-version }})
-    runs-on: ${{ matrix.runner }}
+    name: macOS arm64 wheels (${{ matrix.python-version }})
+    runs-on: macos-14
     strategy:
       fail-fast: true
       matrix:
         include:
           - python-version: '3.11'
             target-version: cp311
-            runner: macos-15
-            architecture: arm64
-            deployment-target: '11.0'
-            bazel-config: macos_arm64_wheel
           - python-version: '3.12'
             target-version: cp312
-            runner: macos-15
-            architecture: arm64
-            deployment-target: '11.0'
-            bazel-config: macos_arm64_wheel
           - python-version: '3.13'
             target-version: cp313
-            runner: macos-15
-            architecture: arm64
-            deployment-target: '11.0'
-            bazel-config: macos_arm64_wheel
-          - python-version: '3.11'
-            target-version: cp311
-            runner: macos-15-intel
-            architecture: x86_64
-            deployment-target: '10.15'
-            bazel-config: macos_x86_64_wheel
-          - python-version: '3.12'
-            target-version: cp312
-            runner: macos-15-intel
-            architecture: x86_64
-            deployment-target: '10.15'
-            bazel-config: macos_x86_64_wheel
-          - python-version: '3.13'
-            target-version: cp313
-            runner: macos-15-intel
-            architecture: x86_64
-            deployment-target: '10.15'
-            bazel-config: macos_x86_64_wheel
     env:
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment-target }}
+      MACOSX_DEPLOYMENT_TARGET: '11.0'
       TARGET_PYTHON: ${{ matrix.python-version }}
       TARGET_VERSION: ${{ matrix.target-version }}
       VERSION: ${{ inputs.version }}
@@ -156,7 +126,7 @@ jobs:
         persist-credentials: false
 
     - name: Verify runner architecture
-      run: test "$(uname -m)" = "${{ matrix.architecture }}"
+      run: test "$(uname -m)" = "arm64"
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -169,91 +139,34 @@ jobs:
         bazelisk-cache: true
         repository-cache: true
 
-    - name: Build and validate macOS wheel
+    - name: Build macOS arm64 wheel
       run: |
         python _update_bazel_py_version.py "$TARGET_PYTHON"
-        bazel build --jobs=1 --config=wheel --config=${{ matrix.bazel-config }} \
+        bazel build --jobs=1 --config=wheel --config=macos_arm64_wheel \
           --define TARGET_VERSION="$TARGET_VERSION" \
           --define VERSION="$VERSION" \
           :tesseract_decoder_wheel
         mkdir -p wheelhouse
         cp bazel-bin/*.whl wheelhouse/
-        python - <<'PY'
-        import pathlib
-        import re
-        import subprocess
-        import zipfile
 
-        wheel = next(pathlib.Path("wheelhouse").glob("*.whl"))
-        match = re.search(
-            r"-macosx_(\d+)_(\d+)_(arm64|x86_64)\.whl$", wheel.name
-        )
-        if match is None:
-            raise SystemExit(f"could not determine macOS tag from {wheel.name}")
-        declared_target = (int(match.group(1)), int(match.group(2)), 0)
+    - name: Check macOS wheel deployment target
+      run: python devtools/check_macos_wheel.py wheelhouse/*.whl
 
-        def parse_version(value):
-            parts = [int(part) for part in value.split(".")]
-            return tuple((parts + [0, 0, 0])[:3])
-
-        inspect_dir = pathlib.Path("wheel-inspect")
-        with zipfile.ZipFile(wheel) as archive:
-            archive.extractall(inspect_dir)
-        extensions = sorted(inspect_dir.rglob("*.so"))
-        if not extensions:
-            raise SystemExit(f"no Mach-O extension found in {wheel.name}")
-
-        for extension in extensions:
-            output = subprocess.check_output(
-                ["otool", "-l", str(extension)], text=True
-            )
-            versions = []
-            for command in re.split(r"\n\s*Load command \d+\n", output):
-                if re.search(r"^\s*cmd LC_BUILD_VERSION$", command, re.MULTILINE):
-                    platform = re.search(
-                        r"^\s*platform\s+(\S+)$", command, re.MULTILINE
-                    )
-                    minos = re.search(
-                        r"^\s*minos\s+(\S+)$", command, re.MULTILINE
-                    )
-                    if platform and platform.group(1) in {"macos", "1"} and minos:
-                        versions.append(("LC_BUILD_VERSION", minos.group(1)))
-                if re.search(
-                    r"^\s*cmd LC_VERSION_MIN_MACOSX$", command, re.MULTILINE
-                ):
-                    version = re.search(
-                        r"^\s*version\s+(\S+)$", command, re.MULTILINE
-                    )
-                    if version:
-                        versions.append(("LC_VERSION_MIN_MACOSX", version.group(1)))
-            if not versions:
-                raise SystemExit(f"no macOS minimum-version load command in {extension}")
-            for command, value in versions:
-                if parse_version(value) > declared_target:
-                    raise SystemExit(
-                        f"{extension}: {command} minimum {value} exceeds "
-                        f"wheel tag macosx_{declared_target[0]}_{declared_target[1]}"
-                    )
-                print(f"{extension}: {command} minimum {value}")
-        PY
+    - name: Install and import-test macOS wheel
+      run: |
         python -m venv /tmp/tesseract-wheel-test
         /tmp/tesseract-wheel-test/bin/python -m pip install \
           --only-binary=:all: \
           wheelhouse/*.whl
         (
           cd /tmp
-          /tmp/tesseract-wheel-test/bin/python - <<'PY'
-        import tesseract_decoder
-        from tesseract_decoder import demutil
-
-        print(tesseract_decoder.__file__)
-        print("wheel import passed")
-        PY
+          /tmp/tesseract-wheel-test/bin/python -c \
+            'import tesseract_decoder; from tesseract_decoder import demutil; print(tesseract_decoder.__file__)'
         )
 
     - name: Upload macOS wheel
       if: inputs.upload_artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: python-wheels-macos-${{ matrix.architecture }}-${{ matrix.python-version }}
+        name: python-wheels-macos-arm64-${{ matrix.python-version }}
         path: wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -103,20 +103,50 @@ jobs:
         path: wheelhouse/*.whl
 
   build_macos_wheels:
-    name: macOS wheels (${{ matrix.python-version }})
-    runs-on: macos-14
+    name: macOS ${{ matrix.architecture }} wheels (${{ matrix.python-version }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: true
       matrix:
         include:
           - python-version: '3.11'
             target-version: cp311
+            runner: macos-15
+            architecture: arm64
+            deployment-target: '11.0'
+            bazel-config: macos_arm64_wheel
           - python-version: '3.12'
             target-version: cp312
+            runner: macos-15
+            architecture: arm64
+            deployment-target: '11.0'
+            bazel-config: macos_arm64_wheel
           - python-version: '3.13'
             target-version: cp313
+            runner: macos-15
+            architecture: arm64
+            deployment-target: '11.0'
+            bazel-config: macos_arm64_wheel
+          - python-version: '3.11'
+            target-version: cp311
+            runner: macos-15-intel
+            architecture: x86_64
+            deployment-target: '10.15'
+            bazel-config: macos_x86_64_wheel
+          - python-version: '3.12'
+            target-version: cp312
+            runner: macos-15-intel
+            architecture: x86_64
+            deployment-target: '10.15'
+            bazel-config: macos_x86_64_wheel
+          - python-version: '3.13'
+            target-version: cp313
+            runner: macos-15-intel
+            architecture: x86_64
+            deployment-target: '10.15'
+            bazel-config: macos_x86_64_wheel
     env:
-      MACOSX_DEPLOYMENT_TARGET: '11.0'
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment-target }}
       TARGET_PYTHON: ${{ matrix.python-version }}
       TARGET_VERSION: ${{ matrix.target-version }}
       VERSION: ${{ inputs.version }}
@@ -124,6 +154,9 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+
+    - name: Verify runner architecture
+      run: test "$(uname -m)" = "${{ matrix.architecture }}"
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -139,7 +172,7 @@ jobs:
     - name: Build and validate macOS wheel
       run: |
         python _update_bazel_py_version.py "$TARGET_PYTHON"
-        bazel build --jobs=1 --config=wheel --config=macos_wheel \
+        bazel build --jobs=1 --config=wheel --config=${{ matrix.bazel-config }} \
           --define TARGET_VERSION="$TARGET_VERSION" \
           --define VERSION="$VERSION" \
           :tesseract_decoder_wheel
@@ -222,5 +255,5 @@ jobs:
       if: inputs.upload_artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: python-wheels-macos-${{ matrix.python-version }}
+        name: python-wheels-macos-${{ matrix.architecture }}-${{ matrix.python-version }}
         path: wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -116,6 +116,7 @@ jobs:
           - python-version: '3.13'
             target-version: cp313
     env:
+      MACOSX_DEPLOYMENT_TARGET: '11.0'
       TARGET_PYTHON: ${{ matrix.python-version }}
       TARGET_VERSION: ${{ matrix.target-version }}
       VERSION: ${{ inputs.version }}
@@ -138,12 +139,70 @@ jobs:
     - name: Build and validate macOS wheel
       run: |
         python _update_bazel_py_version.py "$TARGET_PYTHON"
-        bazel build --jobs=1 --config=wheel \
+        bazel build --jobs=1 --config=wheel --config=macos_wheel \
           --define TARGET_VERSION="$TARGET_VERSION" \
           --define VERSION="$VERSION" \
           :tesseract_decoder_wheel
         mkdir -p wheelhouse
         cp bazel-bin/*.whl wheelhouse/
+        python - <<'PY'
+        import pathlib
+        import re
+        import subprocess
+        import zipfile
+
+        wheel = next(pathlib.Path("wheelhouse").glob("*.whl"))
+        match = re.search(
+            r"-macosx_(\d+)_(\d+)_(arm64|x86_64)\.whl$", wheel.name
+        )
+        if match is None:
+            raise SystemExit(f"could not determine macOS tag from {wheel.name}")
+        declared_target = (int(match.group(1)), int(match.group(2)), 0)
+
+        def parse_version(value):
+            parts = [int(part) for part in value.split(".")]
+            return tuple((parts + [0, 0, 0])[:3])
+
+        inspect_dir = pathlib.Path("wheel-inspect")
+        with zipfile.ZipFile(wheel) as archive:
+            archive.extractall(inspect_dir)
+        extensions = sorted(inspect_dir.rglob("*.so"))
+        if not extensions:
+            raise SystemExit(f"no Mach-O extension found in {wheel.name}")
+
+        for extension in extensions:
+            output = subprocess.check_output(
+                ["otool", "-l", str(extension)], text=True
+            )
+            versions = []
+            for command in re.split(r"\n\s*Load command \d+\n", output):
+                if re.search(r"^\s*cmd LC_BUILD_VERSION$", command, re.MULTILINE):
+                    platform = re.search(
+                        r"^\s*platform\s+(\S+)$", command, re.MULTILINE
+                    )
+                    minos = re.search(
+                        r"^\s*minos\s+(\S+)$", command, re.MULTILINE
+                    )
+                    if platform and platform.group(1) in {"macos", "1"} and minos:
+                        versions.append(("LC_BUILD_VERSION", minos.group(1)))
+                if re.search(
+                    r"^\s*cmd LC_VERSION_MIN_MACOSX$", command, re.MULTILINE
+                ):
+                    version = re.search(
+                        r"^\s*version\s+(\S+)$", command, re.MULTILINE
+                    )
+                    if version:
+                        versions.append(("LC_VERSION_MIN_MACOSX", version.group(1)))
+            if not versions:
+                raise SystemExit(f"no macOS minimum-version load command in {extension}")
+            for command, value in versions:
+                if parse_version(value) > declared_target:
+                    raise SystemExit(
+                        f"{extension}: {command} minimum {value} exceeds "
+                        f"wheel tag macosx_{declared_target[0]}_{declared_target[1]}"
+                    )
+                print(f"{extension}: {command} minimum {value}")
+        PY
         python -m venv /tmp/tesseract-wheel-test
         /tmp/tesseract-wheel-test/bin/python -m pip install \
           --only-binary=:all: \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
+        # Deliberately omit setup-bazel's compiled disk cache. Normal builds
+        # use -march=native, so outputs are unsafe to restore on a hosted
+        # runner exposing a different CPU feature set.
         repository-cache: true
 
     - name: Install clang-format (Linux)
@@ -82,3 +85,13 @@ jobs:
 
     - name: Bazel tests
       run: bazel test src/... //docs:tutorial_jupytext_sync_test
+
+  build-wheels:
+    name: Build and validate distribution wheels
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      version: 0.0.0.dev0
+      upload_artifacts: false
+    permissions:
+      contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        # Deliberately omit setup-bazel's compiled disk cache. Normal builds
-        # use -march=native, so outputs are unsafe to restore on a hosted
-        # runner exposing a different CPU feature set.
+        # Deliberately omit setup-bazel's compiled disk cache. Linux CI uses
+        # -march=native, so cached outputs may be invalid on a hosted runner
+        # exposing a different CPU feature set.
         repository-cache: true
 
     - name: Install clang-format (Linux)
@@ -86,6 +86,8 @@ jobs:
     - name: Bazel tests
       run: bazel test src/... //docs:tutorial_jupytext_sync_test
 
+  # PRs run the same wheel build and import checks used by releases, but do
+  # not upload artifacts. Pushes to main are handled by prerelease.yml.
   build-wheels:
     name: Build and validate distribution wheels
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        # disk-cache: ${{ github.workflow }}-${{ matrix.os }}
         repository-cache: true
 
     - name: Install clang-format (Linux)
@@ -82,4 +81,4 @@ jobs:
         brew install clang-format
 
     - name: Bazel tests
-      run: bazel test src/... //docs:tutorial_jupytext_sync_test
+      run: bazel test --jobs=1 src/... //docs:tutorial_jupytext_sync_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}-${{ matrix.os }}
+        # disk-cache: ${{ github.workflow }}-${{ matrix.os }}
         repository-cache: true
 
     - name: Install clang-format (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
         brew install clang-format
 
     - name: Bazel tests
-      run: bazel test --jobs=1 src/... //docs:tutorial_jupytext_sync_test
+      run: bazel test src/... //docs:tutorial_jupytext_sync_test

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,8 +14,10 @@
 
 name: Pre-release Tesseract
 
+# Pull requests validate the same wheel-building workflow through
+# ci.yml. This workflow is triggered only by pushes to main, so PRs
+# cannot reach either PyPI publishing action below.
 on:
-  pull_request:
   push:
     branches:
     - main
@@ -42,145 +44,19 @@ jobs:
           echo "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  build_linux_wheels:
-    name: Linux wheels (${{ matrix.python-version }})
-    runs-on: ubuntu-24.04
-    container: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
-    needs: [create_version]
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - python-version: '3.11'
-            python-abi: cp311-cp311
-            target-version: cp311
-          - python-version: '3.12'
-            python-abi: cp312-cp312
-            target-version: cp312
-          - python-version: '3.13'
-            python-abi: cp313-cp313
-            target-version: cp313
-    env:
-      PYTHON_BIN: /opt/python/${{ matrix.python-abi }}/bin/python
-      TARGET_PYTHON: ${{ matrix.python-version }}
-      TARGET_VERSION: ${{ matrix.target-version }}
-      VERSION: ${{ needs.create_version.outputs.version }}
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
+  build-wheels:
+    needs: create_version
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      version: ${{ needs.create_version.outputs.version }}
+      upload_artifacts: true
 
-    - name: Set up Bazel
-      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
-      with:
-        bazelisk-version: 1.29.0
-        bazelisk-cache: true
-        repository-cache: true
-
-    - name: Build, repair, and validate Linux wheel
-      run: |
-        export PATH="$(dirname "$PYTHON_BIN"):$PATH"
-        python _update_bazel_py_version.py "$TARGET_PYTHON"
-        bazel build --jobs=1 --config=wheel \
-          --define TARGET_VERSION="$TARGET_VERSION" \
-          --define VERSION="$VERSION" \
-          :tesseract_decoder_wheel
-        mkdir -p wheelhouse
-        auditwheel repair \
-          --plat manylinux_2_28_x86_64 \
-          bazel-bin/*.whl \
-          --wheel-dir wheelhouse
-        auditwheel show wheelhouse/*.whl
-        "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install \
-          --only-binary=:all: \
-          wheelhouse/*.whl
-        (
-          cd /tmp
-          /tmp/tesseract-wheel-test/bin/python - <<'PY'
-        import tesseract_decoder
-        from tesseract_decoder import demutil
-
-        print(tesseract_decoder.__file__)
-        print("wheel import passed")
-        PY
-        )
-
-    - name: Upload Linux wheel
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: python-wheels-linux-${{ matrix.python-version }}
-        path: wheelhouse/*.whl
-
-  build_macos_wheels:
-    name: macOS wheels (${{ matrix.python-version }})
-    runs-on: macos-14
-    needs: [create_version]
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - python-version: '3.11'
-            target-version: cp311
-          - python-version: '3.12'
-            target-version: cp312
-          - python-version: '3.13'
-            target-version: cp313
-    env:
-      TARGET_PYTHON: ${{ matrix.python-version }}
-      TARGET_VERSION: ${{ matrix.target-version }}
-      VERSION: ${{ needs.create_version.outputs.version }}
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Set up Bazel
-      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
-      with:
-        bazelisk-cache: true
-        repository-cache: true
-
-    - name: Build and validate macOS wheel
-      run: |
-        python _update_bazel_py_version.py "$TARGET_PYTHON"
-        bazel build --jobs=1 --config=wheel \
-          --define TARGET_VERSION="$TARGET_VERSION" \
-          --define VERSION="$VERSION" \
-          :tesseract_decoder_wheel
-        mkdir -p wheelhouse
-        cp bazel-bin/*.whl wheelhouse/
-        python -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install \
-          --only-binary=:all: \
-          wheelhouse/*.whl
-        (
-          cd /tmp
-          /tmp/tesseract-wheel-test/bin/python - <<'PY'
-        import tesseract_decoder
-        from tesseract_decoder import demutil
-
-        print(tesseract_decoder.__file__)
-        print("wheel import passed")
-        PY
-        )
-
-    - name: Upload macOS wheel
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: python-wheels-macos-${{ matrix.python-version }}
-        path: wheelhouse/*.whl
-
+  # build-wheels must successfully install and import every wheel before
+  # this publication job can run.
   release-wheels:
     name: Publish all wheels
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [build_linux_wheels, build_macos_wheels]
+    needs: build-wheels
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,6 +15,7 @@
 name: Pre-release Tesseract
 
 on:
+  pull_request:
   push:
     branches:
     - main
@@ -25,6 +26,8 @@ permissions:
 jobs:
   create_version:
     runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.create_version.outputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -32,24 +35,101 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
-      - name: Create version
+      - id: create_version
+        name: Create version
         run: |
-          mkdir version
-          echo "$(python _version.py).dev$(date '+%Y%m%d%H%M%S')" > version/version.txt
-          cat version/version.txt
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: version-file
-          path: version
+          version="$(python _version.py).dev$(date '+%Y%m%d%H%M%S')"
+          echo "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  build_wheels:
-    runs-on: ${{ matrix.os }}
+  build_linux_wheels:
+    name: Linux wheels (${{ matrix.python-version }})
+    runs-on: ubuntu-24.04
+    container: quay.io/pypa/manylinux_2_28_x86_64
     needs: [create_version]
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
-        python-version: ['3.11', '3.12', '3.13']
+        include:
+          - python-version: '3.11'
+            python-abi: cp311-cp311
+            target-version: py311
+          - python-version: '3.12'
+            python-abi: cp312-cp312
+            target-version: py312
+          - python-version: '3.13'
+            python-abi: cp313-cp313
+            target-version: py313
+    env:
+      PYTHON_BIN: /opt/python/${{ matrix.python-abi }}/bin/python
+      TARGET_PYTHON: ${{ matrix.python-version }}
+      TARGET_VERSION: ${{ matrix.target-version }}
+      VERSION: ${{ needs.create_version.outputs.version }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up Bazel
+      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      with:
+        bazelisk-cache: true
+        repository-cache: true
+
+    - name: Build, repair, and validate Linux wheel
+      run: |
+        export PATH="$(dirname "$PYTHON_BIN"):$PATH"
+        python _update_bazel_py_version.py "$TARGET_PYTHON"
+        bazel build --jobs=1 --config=wheel \
+          --define TARGET_VERSION="$TARGET_VERSION" \
+          --define VERSION="$VERSION" \
+          :tesseract_decoder_wheel
+        mkdir -p wheelhouse
+        auditwheel repair \
+          --plat manylinux_2_28_x86_64 \
+          bazel-bin/*.whl \
+          --wheel-dir wheelhouse
+        auditwheel show wheelhouse/*.whl
+        "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
+        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
+        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        (
+          cd /tmp
+          /tmp/tesseract-wheel-test/bin/python - <<'PY'
+        import tesseract_decoder
+        from tesseract_decoder import demutil
+
+        print(tesseract_decoder.__file__)
+        print("wheel import passed")
+        PY
+        )
+
+    - name: Upload Linux wheel
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: python-wheels-linux-${{ matrix.python-version }}
+        path: wheelhouse/*.whl
+
+  build_macos_wheels:
+    name: macOS wheels (${{ matrix.python-version }})
+    runs-on: macos-14
+    needs: [create_version]
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - python-version: '3.11'
+            target-version: py311
+          - python-version: '3.12'
+            target-version: py312
+          - python-version: '3.13'
+            target-version: py313
+    env:
+      TARGET_PYTHON: ${{ matrix.python-version }}
+      TARGET_VERSION: ${{ matrix.target-version }}
+      VERSION: ${{ needs.create_version.outputs.version }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -59,44 +139,47 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: version-file
-        path: version
-
     - name: Set up Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}-${{ matrix.os }}-py${{ matrix.python-version }}
         repository-cache: true
 
-    - name: Set Python Version
-      env:
-        TARGET_PYTHON: ${{ matrix.python-version }}
+    - name: Build and validate macOS wheel
       run: |
-        echo "set version to ${TARGET_PYTHON}"
-        python _update_bazel_py_version.py $TARGET_PYTHON
+        python _update_bazel_py_version.py "$TARGET_PYTHON"
+        bazel build --jobs=1 --config=wheel \
+          --define TARGET_VERSION="$TARGET_VERSION" \
+          --define VERSION="$VERSION" \
+          :tesseract_decoder_wheel
+        mkdir -p wheelhouse
+        cp bazel-bin/*.whl wheelhouse/
+        python -m venv /tmp/tesseract-wheel-test
+        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
+        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        (
+          cd /tmp
+          /tmp/tesseract-wheel-test/bin/python - <<'PY'
+        import tesseract_decoder
+        from tesseract_decoder import demutil
 
-    - name: Build package
-      env:
-        TARGET_PYTHON: ${{ matrix.python-version }}
-      run: |
-        glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
-        export GLIBC_VERSION="${glibc_version//./_}"
-        echo $GLIBC_VERSION
-        sed "s/^MANYLINUX_VERSION.*/MANYLINUX_VERSION=\"manylinux_${GLIBC_VERSION}_x86_64.manylinux2014_x86_64\"/" BUILD -i || true
-        bazel build --define GLIBC_VERSION=$GLIBC_VERSION --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
+        print(tesseract_decoder.__file__)
+        print("wheel import passed")
+        PY
+        )
 
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    - name: Upload macOS wheel
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: python-wheels-${{ matrix.os }}-${{ matrix.python-version }}
-        path: ./bazel-bin/*.whl
-
+        name: python-wheels-macos-${{ matrix.python-version }}
+        path: wheelhouse/*.whl
 
   release-wheels:
     name: Publish all wheels
-    needs: [build_wheels]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build_linux_wheels, build_macos_wheels]
     runs-on: ubuntu-24.04
 
     steps:
@@ -115,7 +198,6 @@ jobs:
         password: ${{ secrets.TEST_PYPI_TOKEN }}
         packages-dir: wheelhouse/
         verbose: true
-
 
     - name: Publish package to pypi
       uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -53,13 +53,13 @@ jobs:
         include:
           - python-version: '3.11'
             python-abi: cp311-cp311
-            target-version: py311
+            target-version: cp311
           - python-version: '3.12'
             python-abi: cp312-cp312
-            target-version: py312
+            target-version: cp312
           - python-version: '3.13'
             python-abi: cp313-cp313
-            target-version: py313
+            target-version: cp313
     env:
       PYTHON_BIN: /opt/python/${{ matrix.python-abi }}/bin/python
       TARGET_PYTHON: ${{ matrix.python-version }}
@@ -73,6 +73,7 @@ jobs:
     - name: Set up Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
+        bazelisk-version: 1.29.0
         bazelisk-cache: true
         repository-cache: true
 
@@ -91,9 +92,9 @@ jobs:
           --wheel-dir wheelhouse
         auditwheel show wheelhouse/*.whl
         "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
-          -r src/py/requirements_lock.txt
-        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        /tmp/tesseract-wheel-test/bin/python -m pip install \
+          --only-binary=:all: \
+          wheelhouse/*.whl
         (
           cd /tmp
           /tmp/tesseract-wheel-test/bin/python - <<'PY'
@@ -121,11 +122,11 @@ jobs:
       matrix:
         include:
           - python-version: '3.11'
-            target-version: py311
+            target-version: cp311
           - python-version: '3.12'
-            target-version: py312
+            target-version: cp312
           - python-version: '3.13'
-            target-version: py313
+            target-version: cp313
     env:
       TARGET_PYTHON: ${{ matrix.python-version }}
       TARGET_VERSION: ${{ matrix.target-version }}
@@ -155,9 +156,9 @@ jobs:
         mkdir -p wheelhouse
         cp bazel-bin/*.whl wheelhouse/
         python -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
-          -r src/py/requirements_lock.txt
-        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        /tmp/tesseract-wheel-test/bin/python -m pip install \
+          --only-binary=:all: \
+          wheelhouse/*.whl
         (
           cd /tmp
           /tmp/tesseract-wheel-test/bin/python - <<'PY'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -45,7 +45,7 @@ jobs:
   build_linux_wheels:
     name: Linux wheels (${{ matrix.python-version }})
     runs-on: ubuntu-24.04
-    container: quay.io/pypa/manylinux_2_28_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
     needs: [create_version]
     strategy:
       fail-fast: true

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -91,8 +91,8 @@ jobs:
           --wheel-dir wheelhouse
         auditwheel show wheelhouse/*.whl
         "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
-        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
+          -r src/py/requirements_lock.txt
         /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
         (
           cd /tmp
@@ -155,8 +155,8 @@ jobs:
         mkdir -p wheelhouse
         cp bazel-bin/*.whl wheelhouse/
         python -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
-        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
+          -r src/py/requirements_lock.txt
         /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
         (
           cd /tmp

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -51,13 +51,13 @@ jobs:
         include:
           - python-version: '3.11'
             python-abi: cp311-cp311
-            target-version: py311
+            target-version: cp311
           - python-version: '3.12'
             python-abi: cp312-cp312
-            target-version: py312
+            target-version: cp312
           - python-version: '3.13'
             python-abi: cp313-cp313
-            target-version: py313
+            target-version: cp313
     env:
       PYTHON_BIN: /opt/python/${{ matrix.python-abi }}/bin/python
       TARGET_PYTHON: ${{ matrix.python-version }}
@@ -71,6 +71,7 @@ jobs:
     - name: Set up Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
+        bazelisk-version: 1.29.0
         bazelisk-cache: true
         repository-cache: true
 
@@ -89,9 +90,9 @@ jobs:
           --wheel-dir wheelhouse
         auditwheel show wheelhouse/*.whl
         "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
-          -r src/py/requirements_lock.txt
-        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        /tmp/tesseract-wheel-test/bin/python -m pip install \
+          --only-binary=:all: \
+          wheelhouse/*.whl
         (
           cd /tmp
           /tmp/tesseract-wheel-test/bin/python - <<'PY'
@@ -118,11 +119,11 @@ jobs:
       matrix:
         include:
           - python-version: '3.11'
-            target-version: py311
+            target-version: cp311
           - python-version: '3.12'
-            target-version: py312
+            target-version: cp312
           - python-version: '3.13'
-            target-version: py313
+            target-version: cp313
     env:
       TARGET_PYTHON: ${{ matrix.python-version }}
       TARGET_VERSION: ${{ matrix.target-version }}
@@ -152,9 +153,9 @@ jobs:
         mkdir -p wheelhouse
         cp bazel-bin/*.whl wheelhouse/
         python -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
-          -r src/py/requirements_lock.txt
-        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        /tmp/tesseract-wheel-test/bin/python -m pip install \
+          --only-binary=:all: \
+          wheelhouse/*.whl
         (
           cd /tmp
           /tmp/tesseract-wheel-test/bin/python - <<'PY'

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -43,7 +43,7 @@ jobs:
   build_linux_wheels:
     name: Linux wheels (${{ matrix.python-version }})
     runs-on: ubuntu-24.04
-    container: quay.io/pypa/manylinux_2_28_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
     needs: [create_version]
     strategy:
       fail-fast: true

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -24,6 +24,8 @@ permissions:
 jobs:
   create_version:
     runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.create_version.outputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -31,25 +33,100 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
-      - name: Create version
+      - id: create_version
+        name: Create version
         run: |
-          mkdir version
-          echo "$(python _version.py)" > version/version.txt
-          cat version/version.txt
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: version-file
-          path: version
+          version="$(python _version.py)"
+          echo "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  build_wheels:
-    runs-on: ${{ matrix.os }}
+  build_linux_wheels:
+    name: Linux wheels (${{ matrix.python-version }})
+    runs-on: ubuntu-24.04
+    container: quay.io/pypa/manylinux_2_28_x86_64
     needs: [create_version]
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
-        python-version: ['3.11', '3.12', '3.13']
+        include:
+          - python-version: '3.11'
+            python-abi: cp311-cp311
+            target-version: py311
+          - python-version: '3.12'
+            python-abi: cp312-cp312
+            target-version: py312
+          - python-version: '3.13'
+            python-abi: cp313-cp313
+            target-version: py313
+    env:
+      PYTHON_BIN: /opt/python/${{ matrix.python-abi }}/bin/python
+      TARGET_PYTHON: ${{ matrix.python-version }}
+      TARGET_VERSION: ${{ matrix.target-version }}
+      VERSION: ${{ needs.create_version.outputs.version }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
+    - name: Set up Bazel
+      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      with:
+        bazelisk-cache: true
+        repository-cache: true
+
+    - name: Build, repair, and validate Linux wheel
+      run: |
+        export PATH="$(dirname "$PYTHON_BIN"):$PATH"
+        python _update_bazel_py_version.py "$TARGET_PYTHON"
+        bazel build --jobs=1 --config=wheel \
+          --define TARGET_VERSION="$TARGET_VERSION" \
+          --define VERSION="$VERSION" \
+          :tesseract_decoder_wheel
+        mkdir -p wheelhouse
+        auditwheel repair \
+          --plat manylinux_2_28_x86_64 \
+          bazel-bin/*.whl \
+          --wheel-dir wheelhouse
+        auditwheel show wheelhouse/*.whl
+        "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
+        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
+        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        (
+          cd /tmp
+          /tmp/tesseract-wheel-test/bin/python - <<'PY'
+        import tesseract_decoder
+        from tesseract_decoder import demutil
+
+        print(tesseract_decoder.__file__)
+        print("wheel import passed")
+        PY
+        )
+
+    - name: Upload Linux wheel
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: python-wheels-linux-${{ matrix.python-version }}
+        path: wheelhouse/*.whl
+
+  build_macos_wheels:
+    name: macOS wheels (${{ matrix.python-version }})
+    runs-on: macos-14
+    needs: [create_version]
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - python-version: '3.11'
+            target-version: py311
+          - python-version: '3.12'
+            target-version: py312
+          - python-version: '3.13'
+            target-version: py313
+    env:
+      TARGET_PYTHON: ${{ matrix.python-version }}
+      TARGET_VERSION: ${{ matrix.target-version }}
+      VERSION: ${{ needs.create_version.outputs.version }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -59,43 +136,46 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: version-file
-        path: version
-
     - name: Set up Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}-${{ matrix.os }}-py${{ matrix.python-version }}
         repository-cache: true
 
-    - name: Set Python Version
-      env:
-        TARGET_PYTHON: ${{ matrix.python-version }}
+    - name: Build and validate macOS wheel
       run: |
-        echo "set version to ${TARGET_PYTHON}"
-        python _update_bazel_py_version.py $TARGET_PYTHON
+        python _update_bazel_py_version.py "$TARGET_PYTHON"
+        bazel build --jobs=1 --config=wheel \
+          --define TARGET_VERSION="$TARGET_VERSION" \
+          --define VERSION="$VERSION" \
+          :tesseract_decoder_wheel
+        mkdir -p wheelhouse
+        cp bazel-bin/*.whl wheelhouse/
+        python -m venv /tmp/tesseract-wheel-test
+        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
+        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
+        (
+          cd /tmp
+          /tmp/tesseract-wheel-test/bin/python - <<'PY'
+        import tesseract_decoder
+        from tesseract_decoder import demutil
 
-    - name: Build package
-      env:
-        TARGET_PYTHON: ${{ matrix.python-version }}
-      run: |
-        glibc_version=$(ldd --version | awk '/ldd/{print $NF}')
-        export GLIBC_VERSION="${glibc_version//./_}"
-        echo $GLIBC_VERSION
-        sed "s/^MANYLINUX_VERSION.*/MANYLINUX_VERSION=\"manylinux_${GLIBC_VERSION}_x86_64.manylinux2014_x86_64\"/" BUILD -i || true
-        bazel build --define TARGET_VERSION="$(python -c "print(\"py${TARGET_PYTHON}\".replace(\".\", \"\"))")" --define VERSION="$(cat version/version.txt)"  :tesseract_decoder_wheel
+        print(tesseract_decoder.__file__)
+        print("wheel import passed")
+        PY
+        )
 
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    - name: Upload macOS wheel
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: python-wheels-${{ matrix.os }}-${{ matrix.python-version }}
-        path: ./bazel-bin/*.whl
+        name: python-wheels-macos-${{ matrix.python-version }}
+        path: wheelhouse/*.whl
 
   release-wheels:
     name: Publish all wheels
-    needs: [build_wheels]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: [build_linux_wheels, build_macos_wheels]
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -89,8 +89,8 @@ jobs:
           --wheel-dir wheelhouse
         auditwheel show wheelhouse/*.whl
         "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
-        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
+          -r src/py/requirements_lock.txt
         /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
         (
           cd /tmp
@@ -152,8 +152,8 @@ jobs:
         mkdir -p wheelhouse
         cp bazel-bin/*.whl wheelhouse/
         python -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install --upgrade pip
-        /tmp/tesseract-wheel-test/bin/python -m pip install numpy scipy stim
+        /tmp/tesseract-wheel-test/bin/python -m pip install --require-hashes \
+          -r src/py/requirements_lock.txt
         /tmp/tesseract-wheel-test/bin/python -m pip install --no-deps wheelhouse/*.whl
         (
           cd /tmp

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -40,143 +40,17 @@ jobs:
           echo "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  build_linux_wheels:
-    name: Linux wheels (${{ matrix.python-version }})
-    runs-on: ubuntu-24.04
-    container: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
-    needs: [create_version]
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - python-version: '3.11'
-            python-abi: cp311-cp311
-            target-version: cp311
-          - python-version: '3.12'
-            python-abi: cp312-cp312
-            target-version: cp312
-          - python-version: '3.13'
-            python-abi: cp313-cp313
-            target-version: cp313
-    env:
-      PYTHON_BIN: /opt/python/${{ matrix.python-abi }}/bin/python
-      TARGET_PYTHON: ${{ matrix.python-version }}
-      TARGET_VERSION: ${{ matrix.target-version }}
-      VERSION: ${{ needs.create_version.outputs.version }}
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-
-    - name: Set up Bazel
-      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
-      with:
-        bazelisk-version: 1.29.0
-        bazelisk-cache: true
-        repository-cache: true
-
-    - name: Build, repair, and validate Linux wheel
-      run: |
-        export PATH="$(dirname "$PYTHON_BIN"):$PATH"
-        python _update_bazel_py_version.py "$TARGET_PYTHON"
-        bazel build --jobs=1 --config=wheel \
-          --define TARGET_VERSION="$TARGET_VERSION" \
-          --define VERSION="$VERSION" \
-          :tesseract_decoder_wheel
-        mkdir -p wheelhouse
-        auditwheel repair \
-          --plat manylinux_2_28_x86_64 \
-          bazel-bin/*.whl \
-          --wheel-dir wheelhouse
-        auditwheel show wheelhouse/*.whl
-        "$PYTHON_BIN" -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install \
-          --only-binary=:all: \
-          wheelhouse/*.whl
-        (
-          cd /tmp
-          /tmp/tesseract-wheel-test/bin/python - <<'PY'
-        import tesseract_decoder
-        from tesseract_decoder import demutil
-
-        print(tesseract_decoder.__file__)
-        print("wheel import passed")
-        PY
-        )
-
-    - name: Upload Linux wheel
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: python-wheels-linux-${{ matrix.python-version }}
-        path: wheelhouse/*.whl
-
-  build_macos_wheels:
-    name: macOS wheels (${{ matrix.python-version }})
-    runs-on: macos-14
-    needs: [create_version]
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - python-version: '3.11'
-            target-version: cp311
-          - python-version: '3.12'
-            target-version: cp312
-          - python-version: '3.13'
-            target-version: cp313
-    env:
-      TARGET_PYTHON: ${{ matrix.python-version }}
-      TARGET_VERSION: ${{ matrix.target-version }}
-      VERSION: ${{ needs.create_version.outputs.version }}
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Set up Bazel
-      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
-      with:
-        bazelisk-cache: true
-        repository-cache: true
-
-    - name: Build and validate macOS wheel
-      run: |
-        python _update_bazel_py_version.py "$TARGET_PYTHON"
-        bazel build --jobs=1 --config=wheel \
-          --define TARGET_VERSION="$TARGET_VERSION" \
-          --define VERSION="$VERSION" \
-          :tesseract_decoder_wheel
-        mkdir -p wheelhouse
-        cp bazel-bin/*.whl wheelhouse/
-        python -m venv /tmp/tesseract-wheel-test
-        /tmp/tesseract-wheel-test/bin/python -m pip install \
-          --only-binary=:all: \
-          wheelhouse/*.whl
-        (
-          cd /tmp
-          /tmp/tesseract-wheel-test/bin/python - <<'PY'
-        import tesseract_decoder
-        from tesseract_decoder import demutil
-
-        print(tesseract_decoder.__file__)
-        print("wheel import passed")
-        PY
-        )
-
-    - name: Upload macOS wheel
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: python-wheels-macos-${{ matrix.python-version }}
-        path: wheelhouse/*.whl
+  build-wheels:
+    needs: create_version
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      version: ${{ needs.create_version.outputs.version }}
+      upload_artifacts: true
 
   release-wheels:
     name: Publish all wheels
     if: github.event_name == 'release' && github.event.action == 'published'
-    needs: [build_linux_wheels, build_macos_wheels]
+    needs: build-wheels
     runs-on: ubuntu-24.04
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,16 +47,19 @@ ctest
 
 ## Building the Python Wheel
 
+Normal local builds remain native. Use `--config=wheel` when building
+distributable Linux wheels.
+
 To build the Python wheel for `tesseract_decoder` locally, you will need to use the `bazel build` command and provide the version and Python target version as command-line arguments. This is because the `py_wheel` rule in the `BUILD` file uses "Make" variable substitution, which expects these values to be defined at build time.
 
 Use the following command:
 
 ```bash
-bazel build --jobs=1 //:tesseract_decoder_wheel --define=VERSION=0.1.1 --define=TARGET_VERSION=py313
+bazel build --jobs=1 --config=wheel //:tesseract_decoder_wheel --define=VERSION=0.1.1 --define=TARGET_VERSION=cp313
 ```
 
 - `--define=VERSION=0.1.1`: Sets the version of the wheel. You should replace `0.1.1` with the current version from the `_version.py` file.
-- `--define=TARGET_VERSION=py313`: Sets the Python version tag for the wheel. Replace `py313` with the appropriate tag for the Python version you are targeting (e.g., `py312` for Python 3.12).
+- `--define=TARGET_VERSION=cp313`: Sets the Python version tag for the wheel. Replace `cp313` with the appropriate tag for the Python version you are targeting (e.g., `cp312` for Python 3.12).
 
 The resulting wheel file will be located in the `bazel-bin/` directory.
 

--- a/BUILD
+++ b/BUILD
@@ -13,8 +13,6 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-MANYLINUX_VERSION="manylinux_2_17_x86_64.manylinux2014_x86_64"
-
 py_wheel(
     name="tesseract_decoder_wheel",
     distribution = "tesseract_decoder",
@@ -35,7 +33,7 @@ py_wheel(
         ":macos_arm": "macosx_11_0_arm64",
         ":macos_x86": "macosx_10_13_x86_64",
         "@platforms//os:windows": "win32",
-        "@platforms//os:linux": MANYLINUX_VERSION,
+        "@platforms//os:linux": "linux_x86_64",
     }),
     strip_path_prefixes = ["src/py", "src"],
     description_file=":package_description",

--- a/BUILD
+++ b/BUILD
@@ -32,7 +32,6 @@ py_wheel(
     abi="$(TARGET_VERSION)",
     platform= select({
         ":macos_arm": "macosx_11_0_arm64",
-        ":macos_x86": "macosx_10_15_x86_64",
         "@platforms//os:windows": "win32",
         "@platforms//os:linux": "linux_x86_64",
     }),
@@ -50,13 +49,5 @@ config_setting(
     constraint_values = [
         "@platforms//os:macos",
         "@platforms//cpu:arm64",
-    ],
-)
-
-config_setting(
-    name = "macos_x86",
-    constraint_values = [
-        "@platforms//os:macos",
-        "@platforms//cpu:x86_64",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -32,7 +32,7 @@ py_wheel(
     abi="$(TARGET_VERSION)",
     platform= select({
         ":macos_arm": "macosx_11_0_arm64",
-        ":macos_x86": "macosx_10_13_x86_64",
+        ":macos_x86": "macosx_10_15_x86_64",
         "@platforms//os:windows": "win32",
         "@platforms//os:linux": "linux_x86_64",
     }),

--- a/BUILD
+++ b/BUILD
@@ -29,6 +29,7 @@ py_wheel(
         "stim",
     ],
     python_tag="$(TARGET_VERSION)",
+    abi="$(TARGET_VERSION)",
     platform= select({
         ":macos_arm": "macosx_11_0_arm64",
         ":macos_x86": "macosx_10_13_x86_64",

--- a/devtools/check_macos_wheel.py
+++ b/devtools/check_macos_wheel.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check that a macOS wheel honors the deployment target its filename declares.
+
+Every Mach-O extension inside the wheel must carry a macOS minimum-version
+load command (LC_BUILD_VERSION or LC_VERSION_MIN_MACOSX) no newer than the
+wheel's platform tag; otherwise pip installs a wheel whose extensions refuse
+to load on the oldest macOS the tag claims to support.
+
+Usage:
+
+    python devtools/check_macos_wheel.py wheelhouse/*.whl
+
+Requires the `otool` command-line tool and uses only the Python standard
+library. Exits nonzero with a diagnostic if the wheel violates its tag.
+"""
+
+import argparse
+import pathlib
+import re
+import subprocess
+import tempfile
+import zipfile
+
+_MACOS_TAG = re.compile(r"-macosx_(\d+)_(\d+)_(arm64|x86_64)\.whl$")
+
+
+def declared_target(wheel):
+    """Returns the deployment target declared by the wheel filename."""
+    match = _MACOS_TAG.search(wheel.name)
+    if match is None:
+        raise SystemExit(f"could not determine macOS tag from {wheel.name}")
+    return (int(match.group(1)), int(match.group(2)), 0)
+
+
+def parse_version(value):
+    parts = [int(part) for part in value.split(".")]
+    return tuple((parts + [0, 0, 0])[:3])
+
+
+def minimum_versions(extension):
+    """Returns (load command, version) pairs declaring a macOS minimum."""
+    output = subprocess.check_output(["otool", "-l", str(extension)], text=True)
+    versions = []
+    for command in re.split(r"\n\s*Load command \d+\n", output):
+        if re.search(r"^\s*cmd LC_BUILD_VERSION$", command, re.MULTILINE):
+            platform = re.search(r"^\s*platform\s+(\S+)$", command, re.MULTILINE)
+            minos = re.search(r"^\s*minos\s+(\S+)$", command, re.MULTILINE)
+            if platform and platform.group(1) in {"macos", "1"} and minos:
+                versions.append(("LC_BUILD_VERSION", minos.group(1)))
+        if re.search(r"^\s*cmd LC_VERSION_MIN_MACOSX$", command, re.MULTILINE):
+            version = re.search(r"^\s*version\s+(\S+)$", command, re.MULTILINE)
+            if version:
+                versions.append(("LC_VERSION_MIN_MACOSX", version.group(1)))
+    return versions
+
+
+def check_wheel(wheel):
+    target = declared_target(wheel)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        with zipfile.ZipFile(wheel) as archive:
+            archive.extractall(root)
+        extensions = sorted(root.rglob("*.so"))
+        if not extensions:
+            raise SystemExit(f"no Mach-O extension found in {wheel.name}")
+        for extension in extensions:
+            name = extension.relative_to(root)
+            versions = minimum_versions(extension)
+            if not versions:
+                raise SystemExit(f"no macOS minimum-version load command in {name}")
+            for command, value in versions:
+                if parse_version(value) > target:
+                    raise SystemExit(
+                        f"{name}: {command} minimum {value} exceeds "
+                        f"wheel tag macosx_{target[0]}_{target[1]}"
+                    )
+                print(f"{name}: {command} minimum {value}")
+    print(f"{wheel.name}: all Mach-O extensions honor macosx_{target[0]}_{target[1]}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check a macOS wheel against its deployment-target tag."
+    )
+    parser.add_argument("wheel", type=pathlib.Path, help="path to one built .whl file")
+    args = parser.parse_args()
+    check_wheel(args.wheel)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/BUILD
+++ b/src/BUILD
@@ -40,14 +40,6 @@ config_setting(
     ],
 )
 
-config_setting(
-    name = "macos_x86",
-    constraint_values = [
-        "@platforms//os:macos",
-        "@platforms//cpu:x86_64",
-    ],
-)
-
 OPT_COPTS = select({
     "//conditions:default": [
         "-Ofast",
@@ -59,7 +51,6 @@ OPT_COPTS = select({
 }) + select({
     ":portable_linux_wheel": ["-march=x86-64"],
     ":macos_arm": ["-mmacosx-version-min=11.0"],
-    ":macos_x86": ["-mmacosx-version-min=10.15"],
     "//conditions:default": ["-march=native",],
 })
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -32,6 +32,22 @@ config_setting(
     define_values = {"tesseract_portable_wheel": "true"},
 )
 
+config_setting(
+    name = "macos_arm",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "macos_x86",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 OPT_COPTS = select({
     "//conditions:default": [
         "-Ofast",
@@ -42,7 +58,8 @@ OPT_COPTS = select({
         "//conditions:default": ["-std=c++20"],
 }) + select({
     ":portable_linux_wheel": ["-march=x86-64"],
-    "@platforms//os:macos": ["-mmacosx-version-min=10.15",],
+    ":macos_arm": ["-mmacosx-version-min=11.0"],
+    ":macos_x86": ["-mmacosx-version-min=10.15"],
     "//conditions:default": ["-march=native",],
 })
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -23,6 +23,15 @@ config_setting(
     values = {"compilation_mode": "dbg"},
 )
 
+config_setting(
+    name = "portable_linux_wheel",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    define_values = {"tesseract_portable_wheel": "true"},
+)
+
 OPT_COPTS = select({
     "//conditions:default": [
         "-Ofast",
@@ -32,6 +41,7 @@ OPT_COPTS = select({
 }) + select({
         "//conditions:default": ["-std=c++20"],
 }) + select({
+    ":portable_linux_wheel": ["-march=x86-64"],
     "@platforms//os:macos": ["-mmacosx-version-min=10.15",],
     "//conditions:default": ["-march=native",],
 })


### PR DESCRIPTION
- don't reuse compiled Bazel outputs across CI runners.
- build Linux distribution wheels with a portable x86-64 baseline in a pinned manylinux container.
- Repair and validate Linux wheels with `auditwheel`.
- Use correct CPython ABI tags.
- Build, install, and import-test Linux x86-64 and macOS ARM64 wheels for Python 3.11-3.13 through one reusable workflow before publication.
- publish macOS arm64 only (end of support for intel macs)
- Run the same build and validation path on pull requests (of course, without uploading or publishing the wheels.)

Fixes #291
Fixes #296