### PR TITLE
Build the Python wheel in pull request CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,10 @@ jobs:
 
     - name: Bazel tests
       run: bazel test src/... //docs:tutorial_jupytext_sync_test
+
+    - name: Build Python wheel
+      run: |
+        bazel build --jobs=1 \
+          --define=VERSION="$(python3 _version.py)" \
+          --define=TARGET_VERSION=py313 \
+          //:tesseract_decoder_wheel


### PR DESCRIPTION
PR CI currently runs the Bazel test suite without building the wheel, so packaging regressions can go unnoticed until a release starts. This builds the Python 3.13 wheel in the existing Linux and macOS jobs without publishing it.

The wheel target completes successfully locally and produces the expected wheel archive.

Fixes #296.