### PR TITLE
Avoid redundant DEM flattening during decoder setup

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -116,6 +116,20 @@ double common::merge_weights(double a, double b) {
          std::log(1 + std::exp(-std::abs(a - b)));
 }
 
+bool common::is_flat(const stim::DetectorErrorModel& dem) {
+  for (const stim::DemInstruction& instruction : dem.instructions) {
+    if (instruction.type == stim::DemInstructionType::DEM_REPEAT_BLOCK ||
+        instruction.type == stim::DemInstructionType::DEM_SHIFT_DETECTORS) {
+      return false;
+    }
+  }
+  return true;
+}
+
+stim::DetectorErrorModel common::flatten(const stim::DetectorErrorModel& dem) {
+  return is_flat(dem) ? dem : dem.flattened();
+}
+
 stim::DetectorErrorModel common::merge_indistinguishable_errors(
     const stim::DetectorErrorModel& dem, std::vector<size_t>& error_index_map) {
   stim::DetectorErrorModel out_dem;
@@ -126,7 +140,7 @@ stim::DetectorErrorModel common::merge_indistinguishable_errors(
   std::unordered_map<Symptom, size_t, Symptom::hash> merged_index_by_symptom;
   std::vector<Error> merged_errors;
 
-  for (const stim::DemInstruction& instruction : dem.flattened().instructions) {
+  for (const stim::DemInstruction& instruction : flatten(dem).instructions) {
     switch (instruction.type) {
       case stim::DemInstructionType::DEM_ERROR: {
         Error error(instruction);
@@ -174,7 +188,7 @@ stim::DetectorErrorModel common::remove_zero_probability_errors(
   stim::DetectorErrorModel out_dem;
   error_index_map.clear();
   size_t output_error_index = 0;
-  for (const stim::DemInstruction& instruction : dem.flattened().instructions) {
+  for (const stim::DemInstruction& instruction : flatten(dem).instructions) {
     switch (instruction.type) {
       case stim::DemInstructionType::DEM_ERROR:
         if (instruction.arg_data[0] > 0) {
@@ -221,7 +235,7 @@ std::vector<size_t> common::invert_error_map(const std::vector<size_t>& error_ma
 stim::DetectorErrorModel common::dem_from_counts(const stim::DetectorErrorModel& orig_dem,
                                                  const std::vector<size_t>& error_counts,
                                                  size_t num_shots) {
-  stim::DetectorErrorModel flat_dem = orig_dem.flattened();
+  stim::DetectorErrorModel flat_dem = flatten(orig_dem);
   if (flat_dem.count_errors() != error_counts.size()) {
     throw std::invalid_argument(
         "Error hits array must be the same size as the number of errors in the "

--- a/src/common.h
+++ b/src/common.h
@@ -71,6 +71,12 @@ struct Error {
   void set_with_probability(double p);
 };
 
+// True if the DEM has no repeat or shift_detectors instructions.
+bool is_flat(const stim::DetectorErrorModel& dem);
+
+// Flatten the DEM, skipping rebuilds if already flat.
+stim::DetectorErrorModel flatten(const stim::DetectorErrorModel& dem);
+
 // Makes a new (flattened) dem where identical error mechanisms have been
 // merged.
 // `error_index_map[old_error_index]` gives the corresponding merged DEM error

--- a/src/simplex.cc
+++ b/src/simplex.cc
@@ -34,9 +34,11 @@ std::string SimplexConfig::str() {
   return ss.str();
 }
 
-SimplexDecoder::SimplexDecoder(SimplexConfig _config) : config(_config) {
+SimplexDecoder::SimplexDecoder(SimplexConfig _config) : config(std::move(_config)) {
+  config.dem = common::flatten(config.dem);
+
   // Maps original flattened DEM error indices to currently preprocessed indices.
-  std::vector<size_t> dem_error_map(config.dem.flattened().count_errors());
+  std::vector<size_t> dem_error_map(config.dem.count_errors());
   std::iota(dem_error_map.begin(), dem_error_map.end(), 0);
 
   if (config.merge_errors) {
@@ -52,7 +54,7 @@ SimplexDecoder::SimplexDecoder(SimplexConfig _config) : config(_config) {
   dem_error_to_error = std::move(dem_error_map);
   error_to_dem_error = common::invert_error_map(dem_error_to_error, config.dem.count_errors());
 
-  errors = get_errors_from_dem(config.dem.flattened());
+  errors = get_errors_from_dem(config.dem);
 
   std::vector<double> detector_t_coords(config.dem.count_detectors(), 0);
   std::vector<std::vector<double>> detector_coords = get_detector_coords(config.dem);

--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <limits>
 #include <numeric>
+#include <utility>
 
 namespace {
 
@@ -150,8 +151,10 @@ double TesseractDecoder::get_detcost(size_t d,
   return (min_cost / min_det_cost_det_count) + config.det_penalty;
 }
 
-TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(config_) {
-  std::vector<size_t> dem_error_map(config.dem.flattened().count_errors());
+TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(std::move(config_)) {
+  config.dem = common::flatten(config.dem);
+
+  std::vector<size_t> dem_error_map(config.dem.count_errors());
   std::iota(dem_error_map.begin(), dem_error_map.end(), 0);
 
   if (config.merge_errors) {
@@ -181,7 +184,7 @@ TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(config_) {
   if (config.det_orders.empty()) {
     throw std::runtime_error("After initialization, detector orders list must not be empty.");
   }
-  errors = get_errors_from_dem(config.dem.flattened());
+  errors = get_errors_from_dem(config.dem);
   if (config.verbose) {
     for (auto& error : errors) {
       std::cout << error.str() << "\n";

--- a/src/tesseract_trellis.cc
+++ b/src/tesseract_trellis.cc
@@ -1187,8 +1187,10 @@ TesseractTrellisDecoder::~TesseractTrellisDecoder() = default;
 
 TesseractTrellisDecoder::TesseractTrellisDecoder(TesseractTrellisConfig config_)
     : config(std::move(config_)) {
+  config.dem = common::flatten(config.dem);
+
   // Maps original flattened DEM error indices to currently preprocessed indices.
-  std::vector<size_t> dem_error_map(config.dem.flattened().count_errors());
+  std::vector<size_t> dem_error_map(config.dem.count_errors());
   std::iota(dem_error_map.begin(), dem_error_map.end(), 0);
 
   if (config.merge_errors) {
@@ -1204,7 +1206,7 @@ TesseractTrellisDecoder::TesseractTrellisDecoder(TesseractTrellisConfig config_)
   dem_error_to_error = std::move(dem_error_map);
   error_to_dem_error = common::invert_error_map(dem_error_to_error, config.dem.count_errors());
 
-  errors = get_errors_from_dem(config.dem.flattened());
+  errors = get_errors_from_dem(config.dem);
   num_detectors = config.dem.count_detectors();
   num_observables = config.dem.count_observables();
   if (num_observables > 1) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -29,7 +29,7 @@
 
 std::vector<std::vector<double>> get_detector_coords(const stim::DetectorErrorModel& dem) {
   std::vector<std::vector<double>> detector_coords;
-  for (const stim::DemInstruction& instruction : dem.flattened().instructions) {
+  for (const stim::DemInstruction& instruction : common::flatten(dem).instructions) {
     switch (instruction.type) {
       case stim::DemInstructionType::DEM_SHIFT_DETECTORS:
         throw std::invalid_argument("DEM_SHIFT_DETECTORS is not supported by this function.");
@@ -58,7 +58,7 @@ std::vector<std::vector<double>> get_detector_coords(const stim::DetectorErrorMo
 std::vector<std::vector<size_t>> build_detector_graph(const stim::DetectorErrorModel& dem) {
   size_t num_detectors = dem.count_detectors();
   std::vector<std::vector<size_t>> neighbors(num_detectors);
-  for (const stim::DemInstruction& instruction : dem.flattened().instructions) {
+  for (const stim::DemInstruction& instruction : common::flatten(dem).instructions) {
     if (instruction.type != stim::DemInstructionType::DEM_ERROR) {
       continue;
     }


### PR DESCRIPTION
Keeps the same semantics at the cost of a few deep copies, with ~1.5–2× speedup in decoder init. 
Most workflows won't notice; mine does.